### PR TITLE
Fixes Firefox modal header icon alignment, because CSS.

### DIFF
--- a/src/HKModal.tsx
+++ b/src/HKModal.tsx
@@ -18,7 +18,7 @@ export default class Modal extends React.Component<IModalProps, {}> {
     return (
       <SRMModal
         containerStyle={{}}
-        containerClassName="w-100 mw7 center bg-white shadow-outer-1 br1"
+        containerClassName="w-100 mw7 center bg-white shadow-outer-1 br1 relative"
         style={{ position: 'fixed', top: 0, bottom: 0, left: 0, right: 0, "zIndex": 9999, background: 'rgba(0,0,0,.2)' }}
         className="flex flex-column items-center justify-center"
         closeOnOuterClick={true}

--- a/src/HKModalHeader.tsx
+++ b/src/HKModalHeader.tsx
@@ -21,7 +21,7 @@ export default class ModalHeader extends React.Component<IModalProps, {}> {
     }
 
     return (
-      <div className="bg-near-white dark-gray bb b--light-silver f4 flex items-center justify-center relative br--top br2">
+      <div className="bg-near-white dark-gray bb b--light-silver f4 flex items-center justify-center br--top br2">
         {childrenNode}
         {dismissNode}
       </div>


### PR DESCRIPTION
### Solution

There's some sort of positioning + rendering bug that occurs when the modal is injected into the DOM, causing (I _think_) a `display: flex` + `position: relative` positioning knife fight on the modal header.

As best as I can figure, by moving the `relative` class up the DOM tree and out of direct conflict with the `flex` class, it fixes the issue.

### Before

![before](https://user-images.githubusercontent.com/1865088/35759282-8cd97884-082d-11e8-8a7c-c8d97e2652cc.png)

### After

![after](https://user-images.githubusercontent.com/1865088/35759281-8cbef1b2-082d-11e8-9f24-fc7d070b5efe.png)

