### PR TITLE
Add testURL to fix Jest complaints

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
       "/node_modules/"
     ],
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$",
+    "testURL": "http://localhost/",
     "moduleFileExtensions": [
       "ts",
       "tsx",


### PR DESCRIPTION
Suite would fail to run with the following error:

`SecurityError: localStorage is not available for opaque origins`

This supplies an origin for JSDom and solves the error.