### PR TITLE
Unbreak HKModal

### DIFF
--- a/src/HKModal.tsx
+++ b/src/HKModal.tsx
@@ -3,6 +3,10 @@ import * as classnames from 'classnames'
 import * as React from 'react'
 import { Transition } from 'react-transition-group'
 import SRMModal from 'simple-react-modal'
+import {
+  default as HKButton,
+  Type as ButtonType,
+} from './HKButton'
 
 export enum Type {
   Actionable = 'actionable',
@@ -10,50 +14,87 @@ export enum Type {
   Presentation = 'presentation',
 }
 
+interface IButtonDefinition {
+  classNames?: string,
+  disabled: boolean,
+  text: string,
+  type: ButtonType,
+  value: string,
+}
+
 interface IModalProps {
   children: React.ReactNode,
   header: React.ReactNode,
-  footer: React.ReactNode,
+  buttons?: IButtonDefinition[],
   isFlyout?: boolean,
-  onDismiss: (...args: any[]) => any,
+  onDismiss: (value?: string) => any,
   show: boolean,
   type?: Type,
 }
 
 interface IModalState {
-  isClosing: boolean
+  isShowing: boolean,
+  isClosing: boolean,
 }
 
+/*
+Dramatis personae of the event flow in this component
+* Show: props.show. Used by the controlling component to indicate a desire to show/hide.
+* iS: state.isShowing. Initially false.
+* iC: state.isClosing. Initially false.
+* in: What should be passed as a prop to <Transition in={ aBoolean } ... />
+
+   Show  iS  iC  in
+1. F     F   F   -   never displayed / displayed and was closed
+2. T     F   F   -   controlling component wants us to display! gDSFP will derive the state on the following line.
+3. T     T   F   T   Shows the modal. In becomes true so transition in happens.
+4. *** props.onDismiss() is called, resulting in the controlling component setting show to F ***
+5. F     T   F   T   controlling component wants us to hide! gDSFP will derive the following state
+6. F     T   T   F   Transition to closed. In becomes false, triggers transition state "exiting"
+7. *** Transition out continues until handleExited() fires, setting isShowing to false
+8. F     F   T   F   Modal is hidden. Transition state is 'exited'
+9. T     F   T   F   Conrolling component wants us to display! gDSFP will take us to step 3.
+*/
 export default class HKModal extends React.Component<IModalProps, IModalState> {
   public static defaultProps: Partial<IModalProps> = {
     isFlyout: false,
   }
 
   public static getDerivedStateFromProps (props, state) {
-    if (!props.show && state.isClosing) {
-      return { isClosing: false }
+    if (props.show) {
+      // reset state, we're showing the thing and not closing at all
+      return { isShowing: true, isClosing: false }
     } else {
-      return state
+      // We're somewhere in the process of closing the modal
+      // isShowing will be set to false by handleExited(),
+      // which is the handler fired at the end of the transition out.
+      return { ...state, isClosing: true }
     }
   }
 
   public state = {
     isClosing: false,
+    isShowing: false,
   }
 
-  public handleClose = () => {
-    this.setState({
-      isClosing: true,
-    })
+  public handleClose = (e: React.MouseEvent<HTMLElement>) => {
+    this.props.onDismiss('cancel')
   }
 
-  public handleExited = (node) => {
-    node.addEventListener('transitionend', this.props.onDismiss, false)
+  public handleButtonClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    this.props.onDismiss(e.currentTarget.value)
+  }
+
+  public handleExited = (node: Element) => {
+    node.addEventListener('transitionend', () => {
+      this.setState({ isShowing: false })
+    }, false)
   }
 
   public render () {
     const duration = 250
-    const { show, children, onDismiss, header, footer, isFlyout, type } = this.props
+    const { show, children, onDismiss, header, buttons, isFlyout, type } = this.props
+    const { isShowing, isClosing } = this.state
 
     const fadeTransition = {
       transition: `background ${duration}ms ease-in-out, opacity ${duration}ms ease-in-out`,
@@ -106,10 +147,13 @@ export default class HKModal extends React.Component<IModalProps, IModalState> {
       'flex-auto': isFlyout,
     }
 
-    const transitionIn = this.state.isClosing ? false : show
+    const footer = (buttons || []).map((b) => (
+      <HKButton key={b.value} value={b.value} type={b.type} disabled={b.disabled} onClick={this.handleButtonClick} className={classnames('ml1', b.classNames)}>{b.text}</HKButton>
+    ))
 
+    // in={!isClosing} is derived from the state table at the top of this component
     return (
-      <Transition in={transitionIn} timeout={0} onExited={this.handleExited}>
+      <Transition in={!isClosing} timeout={0} onExited={this.handleExited}>
         {(state) => (
           <SRMModal
             containerStyle={{
@@ -129,7 +173,7 @@ export default class HKModal extends React.Component<IModalProps, IModalState> {
             }}
             className={classnames('flex flex-column', modalParentClass)}
             closeOnOuterClick={true}
-            show={show}
+            show={isShowing}
             onClose={this.handleClose}
           >
             <div className='bg-near-white dark-gray bb b--light-silver f4 flex items-center justify-center br--top br2'>
@@ -139,7 +183,7 @@ export default class HKModal extends React.Component<IModalProps, IModalState> {
 
             <div className={classnames(modalChildrenClass)}>{children}</div>
 
-            {footer && <div className='bt b--light-silver w-100 pa3 tr'>{footer}</div>}
+            {buttons && <div className='bt b--light-silver w-100 pa3 tr'>{footer}</div>}
           </SRMModal>
         )}
       </Transition>

--- a/stories/HKModal.stories.tsx
+++ b/stories/HKModal.stories.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react'
 
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 
-import { default as HKButton } from '../src/HKButton'
+import {
+  default as HKButton,
+  Type as ButtonType,
+} from '../src/HKButton'
 import { default as HKModal, Type } from '../src/HKModal'
 
 interface IModalWrapperProps {
@@ -38,7 +42,20 @@ class ModalWrapper extends React.Component<
           show={this.state.showModal}
           onDismiss={this.handleModalDismiss}
           header={<div>header text</div>}
-          footer={<HKButton>Submit</HKButton>}
+          buttons={[
+            {
+              disabled: false,
+              text: 'Cancel',
+              type: ButtonType.Tertiary,
+              value: 'cancel',
+            },
+            {
+              disabled: false,
+              text: 'OK',
+              type: this.props.type === Type.Destructive ? ButtonType.Danger : ButtonType.Primary,
+              value: 'ok',
+            },
+          ]}
         >
           <div className='pa6'>with some important details here below</div>
         </HKModal>
@@ -46,8 +63,9 @@ class ModalWrapper extends React.Component<
     )
   }
 
-  private handleModalDismiss = () => {
+  private handleModalDismiss = (value?: string) => {
     this.setState({ showModal: false })
+    action('Modal Dismiss')(value)
   }
 
   private showModal = () => {


### PR DESCRIPTION
When we added transitions, it broke our handling of `onClick` events emanating from the buttons passed into the footer. This actually exposed the fact that we had become uncontrolled.

Solution, make it controlled.

There's a nice doc on the state flow in the HKModal component for your reading pleasure.

Also update stories to properly consume the button events.