### PR TITLE
WIP: Document Prop Types

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,2 @@
+import '@storybook/addon-actions/register'
+import '@storybook/addon-notes/register'

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -16,4 +16,5 @@ addDecorator((storyFn) => {
     </div>)
 })
 
+
 configure(loadStories, module)

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,13 +1,18 @@
 // load the default config generator.
 const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js')
+const TSDocgenPlugin = require('react-docgen-typescript-webpack-plugin')
 module.exports = (baseConfig, env) => {
   const config = genDefaultConfig(baseConfig, env)
   // Extend it as you need.
   // For example, add typescript loader:
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
-    loader: require.resolve('awesome-typescript-loader')
-  })
+    use: [
+      require.resolve('awesome-typescript-loader'),
+      require.resolve('react-docgen-typescript-loader'),
+    ],
+  });
+  config.plugins.push(new TSDocgenPlugin())
   config.resolve.extensions.push('.ts', '.tsx')
   return config
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@heroku/react-malibu": "3.2.0",
     "@types/storybook__addon-actions": "^3.0.1",
+    "@types/storybook__addon-notes": "^3.3.3",
     "classnames": "^2.2.6",
     "d3": "^5.4.0",
     "lodash": "4.17.5",
@@ -21,7 +22,10 @@
     "simple-react-modal": "0.5.1"
   },
   "devDependencies": {
+
+    "markdown-table": "^1.1.2",
     "@storybook/addon-info": "^3.4.10",
+    "@storybook/addon-notes": "^3.4.10",
     "@storybook/addon-storyshots": "^3.3.11",
     "@storybook/react": "^3.3.10",
     "@types/classnames": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "simple-react-modal": "0.5.1"
   },
   "devDependencies": {
+    "@storybook/addon-info": "^3.4.10",
     "@storybook/addon-storyshots": "^3.3.11",
     "@storybook/react": "^3.3.10",
     "@types/classnames": "^2.2.4",
@@ -50,6 +51,8 @@
     "file-loader": "^1.1.11",
     "jest": "^22.1.4",
     "np": "^2.19.0",
+    "react-docgen-typescript-loader": "^2.2.0",
+    "react-docgen-typescript-webpack-plugin": "^1.1.0",
     "react-hot-loader": "^4.3.1",
     "react-test-renderer": "16",
     "ts-jest": "^22.0.1",

--- a/stories/HKButton.stories.tsx
+++ b/stories/HKButton.stories.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { storiesOf } from '@storybook/react'
 
 import { action } from '@storybook/addon-actions'
+import { withInfo } from '@storybook/addon-info'
 
 import { default as HKButton, Type } from '../src/HKButton'
 
@@ -35,11 +36,11 @@ types.forEach((type) => {
 })
 
 storiesOf('HKButton', module)
-  .add('with custom title', () => (
+  .add('with custom title', withInfo({ inline: true, header: false })(() => (
     <HKButton title='a custom title' onClick={action('clicked')}>
       Click Me
     </HKButton>
-  ))
+  )))
   .add('with custom value', () => (
     <HKButton value='a custom value' onClick={action('clicked')}>
       Click Me

--- a/stories/HKButton.stories.tsx
+++ b/stories/HKButton.stories.tsx
@@ -4,6 +4,8 @@ import { storiesOf } from '@storybook/react'
 
 import { action } from '@storybook/addon-actions'
 import { withInfo } from '@storybook/addon-info'
+import { withMarkdownNotes } from '@storybook/addon-notes'
+import { markdownPropsTable } from './util'
 
 import { default as HKButton, Type } from '../src/HKButton'
 
@@ -13,6 +15,7 @@ const types = [
 const smallProp = [true, false]
 const disabledProps = [true, false]
 const asyncProps = [true, false]
+const withPropsTable = withMarkdownNotes(markdownPropsTable(HKButton))
 
 types.forEach((type) => {
   const stories = storiesOf(`HKButton/${type}`, module)
@@ -25,18 +28,18 @@ types.forEach((type) => {
         const disabledStr = disabled ? 'disabled' : 'enabled'
         const asyncStr = isAsync ? 'async' : 'normal'
         const storyName = `${sizeStr}-${disabledStr}-${asyncStr}`
-        stories.add(storyName, () => (
+        stories.add(storyName, withInfo({ inline: true, header: false })(() => (
           <HKButton type={type} small={small} disabled={disabled} async={isAsync} onClick={action('clicked')}>
             Click Me
           </HKButton>
-        ))
+        )))
       })
     })
   })
 })
 
 storiesOf('HKButton', module)
-  .add('with custom title', withInfo({ inline: true, header: false })(() => (
+  .add('with custom title', withPropsTable(() => (
     <HKButton title='a custom title' onClick={action('clicked')}>
       Click Me
     </HKButton>

--- a/stories/util/index.js
+++ b/stories/util/index.js
@@ -1,0 +1,24 @@
+import table from 'markdown-table'
+
+const markdownPropsTable = (component) => {
+  const props = component['__docgenInfo']['props']
+  const propsToMDArray = Object.keys(props).map(type => {
+    return [
+      `\`${type}\``,
+      `\`${props[type].type.name}\``,
+      props[type].defaultValue ? `\`${props[type].defaultValue.value}\`` : `\`${'N/A'}\``,
+    ]
+  })
+  return table([
+    ['Prop', 'Type', 'Default'],
+    ...propsToMDArray
+    ],
+    {
+      align: ['l', 'l', 'l']
+    }
+  )
+}
+
+export {
+  markdownPropsTable
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,22 @@
     react-inspector "^2.2.2"
     uuid "^3.2.1"
 
+"@storybook/addon-info@^3.4.10":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-info/-/addon-info-3.4.10.tgz#fb846457150b6aff690b7886d2b82cf576829bad"
+  dependencies:
+    "@storybook/client-logger" "3.4.10"
+    "@storybook/components" "3.4.10"
+    babel-runtime "^6.26.0"
+    glamor "^2.20.40"
+    glamorous "^4.12.1"
+    global "^4.3.2"
+    marksy "^6.0.3"
+    nested-object-assign "^1.0.1"
+    prop-types "^15.6.1"
+    react-addons-create-fragment "^15.5.3"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-links@3.4.8":
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.4.8.tgz#303e2e37c8abf1861accc95dd9c5f9274bf528ad"
@@ -79,9 +95,21 @@
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.4.8.tgz#df0aff0d20a9597402e76caa7e5ddb088ede3591"
 
+"@storybook/client-logger@3.4.10":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-3.4.10.tgz#510854ee326808a65a20b79e3405763280bc7027"
+
 "@storybook/client-logger@3.4.8":
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-3.4.8.tgz#82d6e1c2cb3e37184cc597a933f64b38fb61b88b"
+
+"@storybook/components@3.4.10":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.4.10.tgz#9af0bba14234d10f14a37656ac5982ec640cfcc8"
+  dependencies:
+    glamor "^2.20.40"
+    glamorous "^4.12.1"
+    prop-types "^15.6.1"
 
 "@storybook/components@3.4.8":
   version "3.4.8"
@@ -412,6 +440,15 @@ ajv@^6.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.1"
+
+ajv@^6.1.1, ajv@^6.5.0:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.3.tgz#71a569d189ecf4f4f321224fecb166f071dd90f9"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1597,6 +1634,10 @@ babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-standalone@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.26.0.tgz#15fb3d35f2c456695815ebf1ed96fe7f015b6886"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0, babel-template@^6.7.0:
   version "6.26.0"
@@ -3763,7 +3804,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -4291,7 +4332,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-he@1.1.x:
+he@1.1.x, he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
@@ -5811,6 +5852,14 @@ marked@^0.3.9:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
 
+marksy@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/marksy/-/marksy-6.0.3.tgz#6079076e8689b563b61be058942090c7ba1f5d20"
+  dependencies:
+    babel-standalone "^6.26.0"
+    he "^1.1.1"
+    marked "^0.3.9"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -6105,6 +6154,10 @@ negotiator@0.6.1:
 neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
+
+nested-object-assign@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nested-object-assign/-/nested-object-assign-1.0.2.tgz#9a84ef51b5c11298b5476d6c65b26458c9eae82b"
 
 next-tick@1:
   version "1.0.0"
@@ -7239,6 +7292,14 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-addons-create-fragment@^15.5.3:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz#a394de7c2c7becd6b5475ba1b97ac472ce7c74f8"
+  dependencies:
+    fbjs "^0.8.4"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.0"
+
 react-deep-force-update@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
@@ -7265,6 +7326,24 @@ react-dev-utils@^5.0.0:
     sockjs-client "1.1.4"
     strip-ansi "3.0.1"
     text-table "0.2.0"
+
+react-docgen-typescript-loader@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-loader/-/react-docgen-typescript-loader-2.2.0.tgz#20d1f9e60e6209013036e28e8acd4eee5bb4c3dd"
+  dependencies:
+    ajv "^6.5.0"
+    react-docgen-typescript "^1.6.0"
+
+react-docgen-typescript-webpack-plugin@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-webpack-plugin/-/react-docgen-typescript-webpack-plugin-1.1.0.tgz#4bfb8c3312fce487083924842cf03f66177ab9df"
+  dependencies:
+    ajv "^6.1.1"
+    react-docgen-typescript "^1.2.3"
+
+react-docgen-typescript@^1.2.3, react-docgen-typescript@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.7.0.tgz#53fce38758a60a246bb3601601b1291500441fa9"
 
 react-docgen@^3.0.0-beta11:
   version "3.0.0-beta9"
@@ -8882,7 +8961,7 @@ upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-uri-js@^4.2.1:
+uri-js@^4.2.1, uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,15 @@
     global "^4.3.2"
     prop-types "^15.6.1"
 
+"@storybook/addon-notes@^3.4.10":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-notes/-/addon-notes-3.4.10.tgz#af3fb5e1e217a92602a0314d0615697b5abdbc9d"
+  dependencies:
+    babel-runtime "^6.26.0"
+    marked "^0.3.17"
+    prop-types "^15.6.1"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-storyshots@^3.3.11":
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/@storybook/addon-storyshots/-/addon-storyshots-3.4.8.tgz#53e8bd697ca26c5880233d6e63690937e10cf183"
@@ -328,6 +337,12 @@
 "@types/storybook__addon-actions@^3.0.1":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/storybook__addon-actions/-/storybook__addon-actions-3.0.3.tgz#99287c0b9ee6b84ea571ee4cb42d0779c56af208"
+
+"@types/storybook__addon-notes@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@types/storybook__addon-notes/-/storybook__addon-notes-3.3.3.tgz#621e5a4936b0ba4d505c1a582da2d58e4c8572b9"
+  dependencies:
+    "@types/react" "*"
 
 "@types/storybook__react@^3.0.6":
   version "3.0.8"
@@ -5848,7 +5863,11 @@ markdown-loader@^2.0.2:
     loader-utils "^1.1.0"
     marked "^0.3.9"
 
-marked@^0.3.9:
+markdown-table@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
+
+marked@^0.3.17, marked@^0.3.9:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
 


### PR DESCRIPTION
Currently, we do a great job of showcasing in Storybook the various states/conditions under which our components can live

We don't do a super job, however, of documenting the APIs of our components in Storybook, meaning you often need to bounce between GitHub / Storybook to understand how to use a specific component.

This PR offers a few different approaches for bringing that lower-level information into Storybook.