### PR TITLE
Use Data Attribute Instead of Ref

### DIFF
--- a/src/HKButton.tsx
+++ b/src/HKButton.tsx
@@ -14,8 +14,8 @@ interface IButtonProps {
   async?: boolean,
   children: React.ReactNode,
   className?: string,
+  'data-testid'?: string,
   disabled?: boolean,
-  forwardedRef: React.RefForwardingComponent<HTMLButtonElement, any>,
   onClick?: (e: React.MouseEvent<HTMLElement>) => void,
   small?: boolean,
   title?: string,
@@ -23,14 +23,12 @@ interface IButtonProps {
   value?: string,
 }
 
-function refHOC (Component) {
-  return React.forwardRef<any, any>((props, ref) => {
-    return <Component {...props} forwardedRef={ref} />
-  })
-}
-
 const HKButton = (props: IButtonProps) => {
-  const { onClick, forwardedRef, async = false, title, value, children, disabled = false, type = 'secondary', small = false, className = '' } = props
+  const { onClick, async = false, title, value, children, disabled = false, type = 'secondary', small = false, className = '' } = props
+  const testId = props['data-testid']
+  const conditionalTestId = testId && {
+    'data-testid': testId,
+  }
   const handleClick = (e: React.MouseEvent<HTMLElement>) => {
     if (onClick) {
       onClick(e)
@@ -50,8 +48,8 @@ const HKButton = (props: IButtonProps) => {
   }
 
   return (
-    <button type='button' ref={forwardedRef} className={buttonClass} disabled={disabled} onClick={handleClick} title={title} value={value || title}> {children} </button>
+    <button type='button' {...conditionalTestId} className={buttonClass} disabled={disabled} onClick={handleClick} title={title} value={value || title}> {children} </button>
   )
 }
 
-export default refHOC(HKButton)
+export default HKButton

--- a/src/HKDropdown.tsx
+++ b/src/HKDropdown.tsx
@@ -46,10 +46,24 @@ export default class HKDropdown extends React.Component<IDropdownProps, IDropdow
     this.setState((prevState) => ({ showDropdown: !prevState.showDropdown }))
   }
 
+  public testId = () => {
+    const { name } = this.props
+    return `${name}-dropdown-button`
+  }
+
   public handleContentClick = () => this.props.closeOnClick && this.setState({ showDropdown: false })
 
   public handleClose = (e) => {
-    if (!e.path.includes(this.buttonRef.current)) {
+    const eventNodes = e.path.filter((node) => {
+      return node.nodeType === 1
+    })
+    const didClickButton = eventNodes.some((node) => {
+      return (
+        node.hasAttribute('data-testid') &&
+        node.getAttribute('data-testid') === this.testId()
+      )
+    })
+    if (!didClickButton) {
       this.setState({
         showDropdown: false,
       })
@@ -65,7 +79,7 @@ export default class HKDropdown extends React.Component<IDropdownProps, IDropdow
         <Reference>
           {({ ref }) => (
             <div className='relative dib' ref={ref}>
-              <HKButton ref={this.buttonRef} onClick={this.handleDropdown} data-testid={`${name}-dropdown-button`} className={classnames({ ph1: !title }, className)} type={Type.Secondary} disabled={disabled}>
+              <HKButton onClick={this.handleDropdown} data-testid={this.testId()} className={classnames({ ph1: !title }, className)} type={Type.Secondary} disabled={disabled}>
                 {title}
                 <MalibuIcon key='icon' name='caret-16' size={16} fillClass='fill-purple' extraClasses={classnames({ pl1: title })} />
               </HKButton>

--- a/src/HKDropdown.tsx
+++ b/src/HKDropdown.tsx
@@ -40,8 +40,6 @@ export default class HKDropdown extends React.Component<IDropdownProps, IDropdow
     showDropdown: false,
   }
 
-  private buttonRef = React.createRef<any>()
-
   public handleDropdown = () => {
     this.setState((prevState) => ({ showDropdown: !prevState.showDropdown }))
   }

--- a/test/__snapshots__/Storyshots.test.ts.snap
+++ b/test/__snapshots__/Storyshots.test.ts.snap
@@ -1908,6 +1908,7 @@ exports[`Storyshots HKDropdown align left 1`] = `
   >
     <button
       className="hk-button--secondary"
+      data-testid="story-dropdown-button"
       disabled={false}
       onClick={[Function]}
       title={undefined}
@@ -1942,6 +1943,7 @@ exports[`Storyshots HKDropdown align right 1`] = `
   >
     <button
       className="hk-button--secondary"
+      data-testid="story-dropdown-button"
       disabled={false}
       onClick={[Function]}
       title={undefined}
@@ -1976,6 +1978,7 @@ exports[`Storyshots HKDropdown default 1`] = `
   >
     <button
       className="hk-button--secondary"
+      data-testid="story-dropdown-button"
       disabled={false}
       onClick={[Function]}
       title={undefined}
@@ -2010,6 +2013,7 @@ exports[`Storyshots HKDropdown disabled 1`] = `
   >
     <button
       className="hk-button--disabled-secondary"
+      data-testid="story-dropdown-button"
       disabled={true}
       onClick={[Function]}
       title={undefined}
@@ -2044,6 +2048,7 @@ exports[`Storyshots HKDropdown no close dropdown onclick 1`] = `
   >
     <button
       className="hk-button--secondary"
+      data-testid="story-dropdown-button"
       disabled={false}
       onClick={[Function]}
       title={undefined}
@@ -2078,6 +2083,7 @@ exports[`Storyshots HKDropdown no title 1`] = `
   >
     <button
       className="hk-button--secondary ph1"
+      data-testid="story-dropdown-button"
       disabled={false}
       onClick={[Function]}
       title={undefined}


### PR DESCRIPTION
As part of release `1.3.1`, In order to implement the "click outside to close" functionality in `HKDropdown`, we had to leverage `refs` and hence modified the API of the `HKButton` component.

I discovered that this introduced a lot of failing tests on `herokudata` and explored different, less complex alternatives. After all, we were only using `refs` to handle an edge case where, if the dropdown menu is open, and you click the dropdown's `HKButton`, the menu wouldn't disappear. 

I noticed that we already have a uniquely-identifying `data-testid` attribute that we're passing down inside of `HKButton`, and decided to use that to handle the aforementioned edge case.

Happy to walk folks through a demo in person if there are questions.