### PR TITLE
Add default props to HKButton

### DIFF
--- a/src/HKButton.tsx
+++ b/src/HKButton.tsx
@@ -52,4 +52,12 @@ const HKButton = (props: IButtonProps) => {
   )
 }
 
+HKButton.defaultProps = {
+  async: false,
+  className: '',
+  disabled: false,
+  small: false,
+  type: 'secondary',
+}
+
 export default HKButton


### PR DESCRIPTION
Oops, I accidentally removed these when I refactored HKButton to be a HOC.