### PR TITLE
defaultProps... FOR REAL

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "tslint": "tslint -c tslint.json --project .",
     "lint": "yarn run eslint && yarn run tslint",
     "storybook": "start-storybook -p ${PORT:-9001} -s ./src/static -c .storybook",
-    "build": "rm -rf ./dist; tsc --project tsconfig.build.json; yarn staticfiles",
+    "build": "rm -rf ./dist && tsc --project tsconfig.build.json && yarn staticfiles",
     "prepublish": "yarn run build",
     "test": "jest --testPathPattern $PWD/test",
     "test:watch": "jest --watch",

--- a/src/HKButton.tsx
+++ b/src/HKButton.tsx
@@ -23,7 +23,15 @@ interface IButtonProps {
   value?: string,
 }
 
-const HKButton = (props: IButtonProps) => {
+const defaultProps = {
+  async: false,
+  className: '',
+  disabled: false,
+  small: false,
+  type: Type.Secondary,
+}
+
+const HKButton: React.SFC<IButtonProps> = (props) => {
   const { onClick, async = false, title, value, children, disabled = false, type = 'secondary', small = false, className = '' } = props
   const testId = props['data-testid']
   const conditionalTestId = testId && {
@@ -52,12 +60,6 @@ const HKButton = (props: IButtonProps) => {
   )
 }
 
-HKButton.defaultProps = {
-  async: false,
-  className: '',
-  disabled: false,
-  small: false,
-  type: 'secondary',
-}
+HKButton.defaultProps = defaultProps
 
 export default HKButton


### PR DESCRIPTION
Use correct API for `defaultProps`.

Convert () => {} to `React.SFC`

Use different syntax for CI job (to ensure build failures kill the job)