### PR TITLE
Fix how we start Storybook in the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint": "eslint ./src",
     "tslint": "tslint -c tslint.json --project .",
     "lint": "yarn run eslint && yarn run tslint",
-    "storybook": "start-storybook -p ${PORT:-9001} -s ./src/static -c .storybook",
+    "storybook": "start-storybook --ci -p ${PORT:-9001} -s ./src/static -c .storybook",
     "build": "yarn run clean && tsc --project tsconfig.build.json && webpack",
     "clean": "rm -rf ./dist",
     "prepublish": "yarn run build",


### PR DESCRIPTION
Otherwise it complains:

ERR! Could not open http://localhost:23330/ inside a browser. If you're running this command inside a
ERR! docker container or on a CI, you need to pass the '--ci' flag to prevent opening a
ERR! browser by default.