### PR TITLE
Fix missing keys in hkmodal

### DIFF
--- a/src/HKModal.tsx
+++ b/src/HKModal.tsx
@@ -174,7 +174,11 @@ export default class HKModal extends React.Component<IModalProps, IModalState> {
             onClose={this.handleClose}
           >
             <div className={classnames('hk-modal-header f4 flex items-center justify-center br--top br2', { 'bg-near-white bb b--light-silver pa4': header, 'red': type === 'destructive' })}>
-              {header && <div>{header}</div>}
+              {/*
+                N.B.: without the wrapper div here, React gets confused because of multiple dynamic children
+                and warns about missing `key` props. There may be a better way to work around this.
+              */
+              header && <div>{header}</div>}
               {dismissElem}
             </div>
 

--- a/src/HKModal.tsx
+++ b/src/HKModal.tsx
@@ -175,10 +175,10 @@ export default class HKModal extends React.Component<IModalProps, IModalState> {
           >
             <div className={classnames('hk-modal-header f4 flex items-center justify-center br--top br2', { 'bg-near-white bb b--light-silver pa4': header, 'red': type === 'destructive' })}>
               {/*
-                N.B.: without the wrapper div here, React gets confused because of multiple dynamic children
-                and warns about missing `key` props. There may be a better way to work around this.
+                N.B.: without the wrapper div Fragment, React gets confused because of
+                multiple dynamic children and warns about missing `key` props.
               */
-              header && <div>{header}</div>}
+              header && <React.Fragment>{header}</React.Fragment>}
               {dismissElem}
             </div>
 

--- a/src/HKModal.tsx
+++ b/src/HKModal.tsx
@@ -174,7 +174,7 @@ export default class HKModal extends React.Component<IModalProps, IModalState> {
             onClose={this.handleClose}
           >
             <div className={classnames('hk-modal-header f4 flex items-center justify-center br--top br2', { 'bg-near-white bb b--light-silver pa4': header, 'red': type === 'destructive' })}>
-              {header}
+              {header && <div>{header}</div>}
               {dismissElem}
             </div>
 

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -3648,9 +3648,7 @@ exports[`Storyshots HKModal/initially open default 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4"
         >
           <div>
-            <div>
-              header text
-            </div>
+            header text
           </div>
           <div
             className="right-1 absolute pointer"
@@ -3765,9 +3763,7 @@ exports[`Storyshots HKModal/initially open default without footer 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4"
         >
           <div>
-            <div>
-              header text
-            </div>
+            header text
           </div>
           <div
             className="right-1 absolute pointer"
@@ -4050,9 +4046,7 @@ exports[`Storyshots HKModal/initially open destructive 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4 red"
         >
           <div>
-            <div>
-              header text
-            </div>
+            header text
           </div>
           <div
             className="right-1 absolute pointer"
@@ -4173,9 +4167,7 @@ exports[`Storyshots HKModal/initially open flyout 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4"
         >
           <div>
-            <div>
-              header text
-            </div>
+            header text
           </div>
           <div
             className="right-1 absolute pointer"
@@ -4296,9 +4288,7 @@ exports[`Storyshots HKModal/initially open flyout without footer 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4"
         >
           <div>
-            <div>
-              header text
-            </div>
+            header text
           </div>
           <div
             className="right-1 absolute pointer"
@@ -4593,9 +4583,7 @@ exports[`Storyshots HKModal/initially open with confirmation 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4 red"
         >
           <div>
-            <div>
-              header text
-            </div>
+            header text
           </div>
           <div
             className="right-1 absolute pointer"

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -3648,7 +3648,9 @@ exports[`Storyshots HKModal/initially open default 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4"
         >
           <div>
-            header text
+            <div>
+              header text
+            </div>
           </div>
           <div
             className="right-1 absolute pointer"
@@ -3763,7 +3765,9 @@ exports[`Storyshots HKModal/initially open default without footer 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4"
         >
           <div>
-            header text
+            <div>
+              header text
+            </div>
           </div>
           <div
             className="right-1 absolute pointer"
@@ -4046,7 +4050,9 @@ exports[`Storyshots HKModal/initially open destructive 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4 red"
         >
           <div>
-            header text
+            <div>
+              header text
+            </div>
           </div>
           <div
             className="right-1 absolute pointer"
@@ -4167,7 +4173,9 @@ exports[`Storyshots HKModal/initially open flyout 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4"
         >
           <div>
-            header text
+            <div>
+              header text
+            </div>
           </div>
           <div
             className="right-1 absolute pointer"
@@ -4288,7 +4296,9 @@ exports[`Storyshots HKModal/initially open flyout without footer 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4"
         >
           <div>
-            header text
+            <div>
+              header text
+            </div>
           </div>
           <div
             className="right-1 absolute pointer"
@@ -4583,7 +4593,9 @@ exports[`Storyshots HKModal/initially open with confirmation 1`] = `
           className="hk-modal-header f4 flex items-center justify-center br--top br2 bg-near-white bb b--light-silver pa4 red"
         >
           <div>
-            header text
+            <div>
+              header text
+            </div>
           </div>
           <div
             className="right-1 absolute pointer"


### PR DESCRIPTION
Because we dynamically include some elements on the page, React
appears to get confused in some situations (have not been able to
reproduce in Storybook, but repros easily in DHC whenever the modal
for rotate credentials is opened) as to which elements are which and
insists on keys. We don't want to modify passed-in elements to set key
props on them, so instead we wrap the header element in a div, which
appears to work around the issue.

Fixes #56