### PR TITLE
Make HKDropdown work in Firefox (and older browsers)

### DIFF
--- a/src/HKDropdown.tsx
+++ b/src/HKDropdown.tsx
@@ -52,7 +52,14 @@ export default class HKDropdown extends React.Component<IDropdownProps, IDropdow
   public handleContentClick = () => this.props.closeOnClick && this.setState({ showDropdown: false })
 
   public handleClose = (e) => {
-    const eventNodes = e.path.filter((node) => {
+    const path = e.path || (e.composedPath && e.composedPath())
+    if (!path) {
+      this.setState({
+        showDropdown: false,
+      })
+      return
+    }
+    const eventNodes = path.filter((node) => {
       return node.nodeType === 1
     })
     const didClickButton = eventNodes.some((node) => {

--- a/src/HKDropdown.tsx
+++ b/src/HKDropdown.tsx
@@ -51,7 +51,10 @@ export default class HKDropdown extends React.Component<IDropdownProps, IDropdow
 
   public handleContentClick = () => this.props.closeOnClick && this.setState({ showDropdown: false })
 
-  public handleClose = (e) => {
+  public handleClickOutside = (e) => {
+    // When closing by clicking on the menu button again,
+    // both this handler and handleDropdown will fire.
+    // Make sure we noop in that scenario so that the dropdown actually closes.
     const path = e.path || (e.composedPath && e.composedPath())
     if (!path) {
       this.setState({
@@ -93,7 +96,7 @@ export default class HKDropdown extends React.Component<IDropdownProps, IDropdow
         </Reference>
         {
           showDropdown && (
-            <OutsideClickHandler onOutsideClick={this.handleClose}>
+            <OutsideClickHandler onOutsideClick={this.handleClickOutside}>
               <Popper placement={popperPlacement}>
                 {({ ref, style, placement }) => (
                   <div className='z-max' onClick={this.handleContentClick} data-testid={`${name}-dropdown-content`} ref={ref} style={style} data-placement={placement}>


### PR DESCRIPTION
### What happened?
When FF users tried to close the "rotate credential" dropdown menu by clicking outside, they got an ugly error in their console. 
```
TypeError: e.path is undefined[Learn More] bundle.608046422ea4d96848a5.min.js:65:67980
t/t.handleClose
```
This happened because I'm a lazy developer and pretend there is only one browser, and one browser only: Google Chrome.

### Diagnosis
The `event` object doesn't have a `path` property in Firefox. The hivemind suggested using `event.composedPath()` instead (https://stackoverflow.com/a/39245638).

I added an extra guard in there, too, such that if we can't detect `path` via the object property or the `composedPath` method, we just hide the dropdown menu. 

### Related Issue
https://trello.com/c/SgEsOB2v/129-error-when-attempting-to-rotate-credentials