### PR TITLE
Specify Display Names for All Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Idan Gazit <idan@heroku.com>",
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@heroku/react-malibu": "^4.0.0",
+    "@heroku/react-malibu": "^4.1.0",
     "classnames": "^2.2.6",
     "d3": "^5.4.0",
     "date-fns": "^1.30.1",

--- a/src/HKBanner.tsx
+++ b/src/HKBanner.tsx
@@ -26,6 +26,8 @@ interface IBannerProps {
 }
 
 export default class HKBanner extends React.Component<IBannerProps> {
+  public static displayName = 'HKBanner'
+
   private typeMap = {
     [BannerType.generic]: ButtonType.Secondary,
     [BannerType.info]: ButtonType.Info,

--- a/src/HKBarChart.tsx
+++ b/src/HKBarChart.tsx
@@ -17,6 +17,7 @@ interface IBarChartState {
 }
 
 export default class HKBarChart extends React.Component<IBarChartProps, IBarChartState> {
+  public static displayName = 'HKBarChart'
 
   constructor (props) {
     super(props)

--- a/src/HKBarChartData.tsx
+++ b/src/HKBarChartData.tsx
@@ -30,6 +30,7 @@ interface IBarChartDataState {
 }
 
 export default class HKBarChartData extends React.PureComponent<IBarChartDataProps, IBarChartDataState> {
+  public static displayName = 'HKBarChartData'
 
   public static getDerivedStateFromProps (newProps, prevState) {
     if (['data', 'width', 'height', 'toggleInfo'].every((o) => newProps[o] === prevState[o])) {

--- a/src/HKButton.tsx
+++ b/src/HKButton.tsx
@@ -61,5 +61,6 @@ const HKButton: React.FunctionComponent<IButtonProps> = (props) => {
 }
 
 HKButton.defaultProps = defaultProps
+HKButton.displayName = 'HKButton'
 
 export default HKButton

--- a/src/HKDropdown.tsx
+++ b/src/HKDropdown.tsx
@@ -30,6 +30,8 @@ interface IDropdownState {
 }
 
 export default class HKDropdown extends React.Component<IDropdownProps, IDropdownState> {
+  public static displayName = 'HKDropdown'
+
   public static defaultProps = {
     closeOnClick: true,
     disabled: false,

--- a/src/HKFlagIcon.tsx
+++ b/src/HKFlagIcon.tsx
@@ -20,6 +20,8 @@ interface IFlagIconProps {
 }
 
 export default class HKFlagIcon extends React.Component<IFlagIconProps> {
+  public static displayName = 'HKFlagIcon'
+
   public static defaultProps = {
     basePath: '/static/dist/flags/',
     className: '',

--- a/src/HKGrid.tsx
+++ b/src/HKGrid.tsx
@@ -12,6 +12,8 @@ interface IGridProps {
 }
 
 export default class HKGrid extends React.PureComponent<IGridProps, {}> {
+  public static displayName = 'HKGrid'
+
   public render () {
     const { width, height, type, yScale } = this.props
 

--- a/src/HKLegendItem.tsx
+++ b/src/HKLegendItem.tsx
@@ -16,6 +16,8 @@ interface IHKLegendItemProps {
 }
 
 export default class HKLegendItem extends React.PureComponent<IHKLegendItemProps, {}> {
+  public static displayName = 'HKLegendItem'
+
   public static defaultProps = {
     disableToggle: false,
   }

--- a/src/HKLine.tsx
+++ b/src/HKLine.tsx
@@ -7,6 +7,7 @@ interface ILineProps {
 }
 
 export default class HKLine extends React.PureComponent<ILineProps, {}> {
+  public static displayName = 'HKLine'
 
   public render () {
     const { line, area, data } = this.props

--- a/src/HKLineChart.tsx
+++ b/src/HKLineChart.tsx
@@ -18,6 +18,7 @@ interface ILineChartState {
 }
 
 export default class HKLineChart extends React.Component<ILineChartProps, ILineChartState> {
+  public static displayName = 'HKLineChart'
 
   constructor (props) {
     super(props)

--- a/src/HKLineChartData.tsx
+++ b/src/HKLineChartData.tsx
@@ -45,6 +45,8 @@ interface ILineChartDataState {
 }
 
 export default class HKLineChartData extends React.PureComponent<ILineChartDataProps, ILineChartDataState> {
+  public static displayName = 'HKLineChartData'
+
   // setState based on new props passed
   public static getDerivedStateFromProps (newProps, prevState) {
     if (['data', 'width', 'height'].every((o) => newProps[o] === prevState[o])) {

--- a/src/HKModal.tsx
+++ b/src/HKModal.tsx
@@ -56,6 +56,8 @@ Dramatis personae of the event flow in this component
 9. T     F   T   F   Controlling component wants us to display! gDSFP will take us to step 3.
 */
 export default class HKModal extends React.Component<IModalProps, IModalState> {
+  public static displayName = 'HKModal'
+
   public static defaultProps: Partial<IModalProps> = {
     isFlyout: false,
   }

--- a/src/HKResizeContainer.tsx
+++ b/src/HKResizeContainer.tsx
@@ -11,6 +11,8 @@ interface IResizeContainerState {
 }
 
 export default class HKResizeContainer extends React.PureComponent<IResizeContainerProps, IResizeContainerState> {
+  public static displayName = 'HKResizeContainer'
+
   constructor (props) {
     super(props)
 

--- a/src/HKTable.tsx
+++ b/src/HKTable.tsx
@@ -6,5 +6,9 @@ import {
   default as HKTablePagination,
 } from './HKTablePagination'
 
-const HKTable = (props) => <ReactTable {...props} PaginationComponent={HKTablePagination} />
+const HKTable: React.FunctionComponent<any> = (props) => {
+  return <ReactTable {...props} PaginationComponent={HKTablePagination} />
+}
+
+HKTable.displayName = 'HKTable'
 export default HKTable

--- a/src/HKTableHeader.tsx
+++ b/src/HKTableHeader.tsx
@@ -13,7 +13,7 @@ interface IHeaderPropTypes {
   sort: ISort,
 }
 
-const HKTableHeader = ({ label, id, sort }: IHeaderPropTypes) => {
+const HKTableHeader: React.FunctionComponent<any> = ({ label, id, sort }: IHeaderPropTypes) => {
   return (
     <div className='pa2 dark-gray tl ttc b f5 flex items-center'>
       {sort.id === id && <MalibuIcon name={sort.desc ? 'direction-up-16' : 'direction-down-16'} size={16} extraClasses={classnames('malibu-fill-gradient-dark-gray')} />}
@@ -22,4 +22,5 @@ const HKTableHeader = ({ label, id, sort }: IHeaderPropTypes) => {
   )
 }
 
+HKTableHeader.displayName = 'HKTableHeader'
 export default HKTableHeader

--- a/src/HKTablePagination.tsx
+++ b/src/HKTablePagination.tsx
@@ -34,7 +34,7 @@ const buildPager = (totalItems, currentPage, pageSize) => {
   return range(startPage, endPage + 1)
 }
 
-const HKTablePagination = (props: IPaginationProps) => {
+const HKTablePagination: React.FunctionComponent<any> = (props: IPaginationProps) => {
   const { page, pages, onPageChange } = props
 
   const currentPage = page + 1
@@ -80,4 +80,5 @@ const HKTablePagination = (props: IPaginationProps) => {
   )
 }
 
+HKTablePagination.displayName = 'HKTablePagination'
 export default HKTablePagination

--- a/src/HKTextField.tsx
+++ b/src/HKTextField.tsx
@@ -32,5 +32,6 @@ const HKTextField: React.FunctionComponent<ITextFieldProps> = (props) => {
 }
 
 HKTextField.defaultProps = defaultProps
+HKTextField.displayName = 'HKTextField'
 
 export default HKTextField

--- a/src/HKTooltip.tsx
+++ b/src/HKTooltip.tsx
@@ -11,6 +11,8 @@ interface IHKTooltipProps {
 }
 
 export default class HKTooltip extends React.PureComponent<IHKTooltipProps, {}> {
+  public static displayName = 'HKTooltip'
+
   public render () {
     const { children, height, width, xPos, yPos, style } = this.props
     const styleProps = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,7 @@ module.exports = {
     minimizer: [
       new UglifyJsPlugin({
         uglifyOptions: {
-          mangle: false,
-          keep_fnames: true,
+          keep_fnames: true
         }
       })
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,10 +775,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.1.3.tgz#b700d97385fa91affed60c71dfd51c67e9dad762"
   integrity sha512-QsYGKdhhuDFNq7bjm2r44y0mp5xW3uO3csuTPDWZc0OIiMQv+AIY5Cqwd4mJiC5N8estVl7qlvOx1hbtOuUWbw==
 
-"@heroku/react-malibu@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@heroku/react-malibu/-/react-malibu-4.0.0.tgz#11a73743f4e79d6c209f4439115edb93367b6a00"
-  integrity sha512-yMlMvvoPS/NNPPIv1g44GnPEkA5mbE7Xg3eFDeVHm824IrA52hULw/gFmQFtJ24PcKT0RHxxlVTRmibI+i46GQ==
+"@heroku/react-malibu@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@heroku/react-malibu/-/react-malibu-4.1.0.tgz#b03325736a7b52a2591aeffb01981083c88f1663"
+  integrity sha512-+yaDtUOSVJ2Tj9wT1490lnB0DYmbWIYyQfpvxEZX8SH9eIR5zDtxOpkIIbmsNIHBtp0kvKnYnyFPPz1rkyfjBQ==
   dependencies:
     babel-polyfill "^6.23.0"
     prop-types "^15.6.2"


### PR DESCRIPTION
Giving each component a `displayName` means that they can be imported from the UMD bundle (which undergoes an "uglification" step via Webpack) with a legible name.

This fixes https://github.com/heroku/react-hk-components/issues/61.