### PR TITLE
Scroll Table Up onPageChange

### DIFF
--- a/src/HKTable.tsx
+++ b/src/HKTable.tsx
@@ -5,7 +5,26 @@ import './static/styles/table.css'
 import { default as HKTablePagination } from './HKTablePagination'
 
 const HKTable: React.FunctionComponent<any> = props => {
-  return <ReactTable {...props} PaginationComponent={HKTablePagination} />
+  const tableRef = React.createRef<HTMLDivElement>()
+
+  const handlePageChange = (...args) => {
+    if (tableRef.current) {
+      tableRef.current.scrollIntoView()
+    }
+    if (props.onPageChange) {
+      props.onPageChange(...args)
+    }
+  }
+
+  return (
+    <div ref={tableRef}>
+      <ReactTable
+        {...props}
+        onPageChange={handlePageChange}
+        PaginationComponent={HKTablePagination}
+      />
+    </div>
+  )
 }
 
 HKTable.displayName = 'HKTable'

--- a/stories/HKTable.stories.tsx
+++ b/stories/HKTable.stories.tsx
@@ -1,36 +1,42 @@
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 
-import {
-  default as HKTable,
-} from '../src/HKTable'
+import { default as HKTable } from '../src/HKTable'
 
-import {
-  default as HKTableHeader,
-} from '../src/HKTableHeader'
+import { default as HKTableHeader } from '../src/HKTableHeader'
 
-const data = [{
-  age: 26,
-  name: 'Tanner Linsley',
-}]
+const data = [
+  {
+    age: 26,
+    name: 'Tanner Linsley',
+  },
+]
+
+const paginatedData = Array.from(new Array(500), () => ({
+  age: 18,
+  name: 'Matt Rothenberg',
+}))
 
 const sort = {
   desc: false,
   id: 'name',
 }
 
-const columns = [{
-  Header: () => <HKTableHeader label='Name' id='name' sort={sort} />,
-  accessor: 'name',
-}, {
-  Header: () => <HKTableHeader label='Age' id='age' sort={sort} />,
-  accessor: 'age',
-}]
+const columns = [
+  {
+    Header: () => <HKTableHeader label='Name' id='name' sort={sort} />,
+    accessor: 'name',
+  },
+  {
+    Header: () => <HKTableHeader label='Age' id='age' sort={sort} />,
+    accessor: 'age',
+  },
+]
 
 storiesOf('HKTable', module)
   .add(`Without Pagination`, () => (
     <HKTable showPagination={false} columns={columns} data={data} />
   ))
   .add(`With Pagination`, () => (
-    <HKTable showPagination={true} columns={columns} data={data} />
+    <HKTable showPagination={true} columns={columns} data={paginatedData} />
   ))

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -4673,120 +4673,33 @@ exports[`Storyshots HKTable With Pagination 1`] = `
       }
     }
   />
-  <div
-    className="ReactTable"
-    style={Object {}}
-  >
+  <div>
     <div
-      className="rt-table"
-      role="grid"
-      style={undefined}
+      className="ReactTable"
+      style={Object {}}
     >
       <div
-        className="rt-thead -header"
-        style={
-          Object {
-            "minWidth": "200px",
-          }
-        }
+        className="rt-table"
+        role="grid"
+        style={undefined}
       >
         <div
-          className="rt-tr"
-          role="row"
-          style={undefined}
-        >
-          <div
-            className="rt-th rt-resizable-header -cursor-pointer"
-            onClick={[Function]}
-            role="columnheader"
-            style={
-              Object {
-                "flex": "100 0 auto",
-                "maxWidth": null,
-                "width": "100px",
-              }
+          className="rt-thead -header"
+          style={
+            Object {
+              "minWidth": "200px",
             }
-            tabIndex="-1"
-          >
-            <div
-              className="rt-resizable-header-content"
-            >
-              <div
-                className="pa2 dark-gray tl ttc b f5 flex items-center"
-              >
-                <svg
-                  className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
-                  style={
-                    Object {
-                      "height": "16px",
-                      "width": "16px",
-                    }
-                  }
-                >
-                  <use
-                    xlinkHref="#direction-down-16"
-                  />
-                </svg>
-                Name
-              </div>
-            </div>
-            <div
-              className="rt-resizer"
-              onMouseDown={[Function]}
-              onTouchStart={[Function]}
-            />
-          </div>
-          <div
-            className="rt-th rt-resizable-header -cursor-pointer"
-            onClick={[Function]}
-            role="columnheader"
-            style={
-              Object {
-                "flex": "100 0 auto",
-                "maxWidth": null,
-                "width": "100px",
-              }
-            }
-            tabIndex="-1"
-          >
-            <div
-              className="rt-resizable-header-content"
-            >
-              <div
-                className="pa2 dark-gray tl ttc b f5 flex items-center"
-              >
-                Age
-              </div>
-            </div>
-            <div
-              className="rt-resizer"
-              onMouseDown={[Function]}
-              onTouchStart={[Function]}
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="rt-tbody"
-        style={
-          Object {
-            "minWidth": "200px",
           }
-        }
-      >
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
         >
           <div
-            className="rt-tr -odd"
+            className="rt-tr"
             role="row"
             style={undefined}
           >
             <div
-              className="rt-td"
+              className="rt-th rt-resizable-header -cursor-pointer"
               onClick={[Function]}
-              role="gridcell"
+              role="columnheader"
               style={
                 Object {
                   "flex": "100 0 auto",
@@ -4794,13 +4707,40 @@ exports[`Storyshots HKTable With Pagination 1`] = `
                   "width": "100px",
                 }
               }
+              tabIndex="-1"
             >
-              Tanner Linsley
+              <div
+                className="rt-resizable-header-content"
+              >
+                <div
+                  className="pa2 dark-gray tl ttc b f5 flex items-center"
+                >
+                  <svg
+                    className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                    style={
+                      Object {
+                        "height": "16px",
+                        "width": "16px",
+                      }
+                    }
+                  >
+                    <use
+                      xlinkHref="#direction-down-16"
+                    />
+                  </svg>
+                  Name
+                </div>
+              </div>
+              <div
+                className="rt-resizer"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              />
             </div>
             <div
-              className="rt-td"
+              className="rt-th rt-resizable-header -cursor-pointer"
               onClick={[Function]}
-              role="gridcell"
+              role="columnheader"
               style={
                 Object {
                   "flex": "100 0 auto",
@@ -4808,818 +4748,962 @@ exports[`Storyshots HKTable With Pagination 1`] = `
                   "width": "100px",
                 }
               }
+              tabIndex="-1"
             >
-              26
+              <div
+                className="rt-resizable-header-content"
+              >
+                <div
+                  className="pa2 dark-gray tl ttc b f5 flex items-center"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                className="rt-resizer"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              />
             </div>
           </div>
         </div>
         <div
-          className="rt-tr-group"
-          role="rowgroup"
+          className="rt-tbody"
+          style={
+            Object {
+              "minWidth": "200px",
+            }
+          }
         >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="pagination-bottom"
-    >
       <div
-        className="pv4 ph3 mw8 center"
+        className="pagination-bottom"
       >
         <div
-          className="flex items-center justify-between"
+          className="pv4 ph3 mw8 center"
         >
-          <button
-            className="hk-button--disabled-tertiary"
-            disabled={true}
-            onClick={[Function]}
-            title={undefined}
-            type="button"
-            value={undefined}
-          >
-             
-            Previous
-             
-          </button>
           <div
-            className="purple"
+            className="flex items-center justify-between"
           >
             <button
-              className="hk-button--tertiary bg-lightest-purple"
+              className="hk-button--disabled-tertiary"
+              disabled={true}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              Previous
+               
+            </button>
+            <div
+              className="purple"
+            >
+              <button
+                className="hk-button--tertiary bg-lightest-purple"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                1
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                2
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                3
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                4
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                5
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                6
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                7
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                8
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                9
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                10
+                 
+              </button>
+            </div>
+            <button
+              className="hk-button--tertiary"
               disabled={false}
               onClick={[Function]}
               title={undefined}
@@ -5627,32 +5711,33 @@ exports[`Storyshots HKTable With Pagination 1`] = `
               value={undefined}
             >
                
-              1
+              Next
+              <svg
+                className="malibu-fill-gradient-purple ml1"
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#direction-right-28"
+                />
+              </svg>
                
             </button>
           </div>
-          <button
-            className="hk-button--disabled-tertiary"
-            disabled={true}
-            onClick={[Function]}
-            title={undefined}
-            type="button"
-            value={undefined}
-          >
-             
-            Next
-             
-          </button>
         </div>
       </div>
-    </div>
-    <div
-      className="-loading"
-    >
       <div
-        className="-loading-inner"
+        className="-loading"
       >
-        Loading...
+        <div
+          className="-loading-inner"
+        >
+          Loading...
+        </div>
       </div>
     </div>
   </div>
@@ -5669,120 +5754,33 @@ exports[`Storyshots HKTable Without Pagination 1`] = `
       }
     }
   />
-  <div
-    className="ReactTable"
-    style={Object {}}
-  >
+  <div>
     <div
-      className="rt-table"
-      role="grid"
-      style={undefined}
+      className="ReactTable"
+      style={Object {}}
     >
       <div
-        className="rt-thead -header"
-        style={
-          Object {
-            "minWidth": "200px",
-          }
-        }
+        className="rt-table"
+        role="grid"
+        style={undefined}
       >
         <div
-          className="rt-tr"
-          role="row"
-          style={undefined}
-        >
-          <div
-            className="rt-th rt-resizable-header -cursor-pointer"
-            onClick={[Function]}
-            role="columnheader"
-            style={
-              Object {
-                "flex": "100 0 auto",
-                "maxWidth": null,
-                "width": "100px",
-              }
+          className="rt-thead -header"
+          style={
+            Object {
+              "minWidth": "200px",
             }
-            tabIndex="-1"
-          >
-            <div
-              className="rt-resizable-header-content"
-            >
-              <div
-                className="pa2 dark-gray tl ttc b f5 flex items-center"
-              >
-                <svg
-                  className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
-                  style={
-                    Object {
-                      "height": "16px",
-                      "width": "16px",
-                    }
-                  }
-                >
-                  <use
-                    xlinkHref="#direction-down-16"
-                  />
-                </svg>
-                Name
-              </div>
-            </div>
-            <div
-              className="rt-resizer"
-              onMouseDown={[Function]}
-              onTouchStart={[Function]}
-            />
-          </div>
-          <div
-            className="rt-th rt-resizable-header -cursor-pointer"
-            onClick={[Function]}
-            role="columnheader"
-            style={
-              Object {
-                "flex": "100 0 auto",
-                "maxWidth": null,
-                "width": "100px",
-              }
-            }
-            tabIndex="-1"
-          >
-            <div
-              className="rt-resizable-header-content"
-            >
-              <div
-                className="pa2 dark-gray tl ttc b f5 flex items-center"
-              >
-                Age
-              </div>
-            </div>
-            <div
-              className="rt-resizer"
-              onMouseDown={[Function]}
-              onTouchStart={[Function]}
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="rt-tbody"
-        style={
-          Object {
-            "minWidth": "200px",
           }
-        }
-      >
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
         >
           <div
-            className="rt-tr -odd"
+            className="rt-tr"
             role="row"
             style={undefined}
           >
             <div
-              className="rt-td"
+              className="rt-th rt-resizable-header -cursor-pointer"
               onClick={[Function]}
-              role="gridcell"
+              role="columnheader"
               style={
                 Object {
                   "flex": "100 0 auto",
@@ -5790,13 +5788,40 @@ exports[`Storyshots HKTable Without Pagination 1`] = `
                   "width": "100px",
                 }
               }
+              tabIndex="-1"
             >
-              Tanner Linsley
+              <div
+                className="rt-resizable-header-content"
+              >
+                <div
+                  className="pa2 dark-gray tl ttc b f5 flex items-center"
+                >
+                  <svg
+                    className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                    style={
+                      Object {
+                        "height": "16px",
+                        "width": "16px",
+                      }
+                    }
+                  >
+                    <use
+                      xlinkHref="#direction-down-16"
+                    />
+                  </svg>
+                  Name
+                </div>
+              </div>
+              <div
+                className="rt-resizer"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              />
             </div>
             <div
-              className="rt-td"
+              className="rt-th rt-resizable-header -cursor-pointer"
               onClick={[Function]}
-              role="gridcell"
+              role="columnheader"
               style={
                 Object {
                   "flex": "100 0 auto",
@@ -5804,799 +5829,861 @@ exports[`Storyshots HKTable Without Pagination 1`] = `
                   "width": "100px",
                 }
               }
+              tabIndex="-1"
             >
-              26
+              <div
+                className="rt-resizable-header-content"
+              >
+                <div
+                  className="pa2 dark-gray tl ttc b f5 flex items-center"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                className="rt-resizer"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              />
             </div>
           </div>
         </div>
         <div
-          className="rt-tr-group"
-          role="rowgroup"
+          className="rt-tbody"
+          style={
+            Object {
+              "minWidth": "200px",
+            }
+          }
         >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                Tanner Linsley
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                26
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -odd"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
-            </div>
-            <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
                 }
-              }
-            >
-              <span>
-                 
-              </span>
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="rt-tr-group"
-          role="rowgroup"
-        >
           <div
-            className="rt-tr -padRow -even"
-            role="row"
-            style={Object {}}
+            className="rt-tr-group"
+            role="rowgroup"
           >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -odd"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
             <div
-              className="rt-td"
-              role="gridcell"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
+              className="rt-tr -padRow -even"
+              role="row"
+              style={Object {}}
             >
-              <span>
-                 
-              </span>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
+              <div
+                className="rt-td"
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                <span>
+                   
+                </span>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="-loading"
-    >
       <div
-        className="-loading-inner"
+        className="-loading"
       >
-        Loading...
+        <div
+          className="-loading-inner"
+        >
+          Loading...
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
https://trello.com/c/BEEOfNb1/191-paginated-list-of-dataclips-table-should-scroll-to-the-top-when-clicking-next-to-page

When paging through a paginated `HKTable`, the table should scroll back to the top on page change. This functionality was achieved by:

1. Creating a `ref`.
2. Wrapping `ReactTable` in a div and assigning it said `ref`.
3. Invoking `scrollIntoView` on the ref when the `onPageChange` event is triggered.
4. Invoking the user's `onPageChange` callback as well, if one is passed.