### PR TITLE
HKTable Bugfixes

### DIFF
--- a/src/HKTable.tsx
+++ b/src/HKTable.tsx
@@ -9,17 +9,35 @@ const HKTable: React.FunctionComponent<any> = props => {
 
   const handlePageChange = (...args) => {
     if (tableRef.current) {
-      tableRef.current.scrollIntoView()
+      const isFixedHeight = !!props.height
+      if (isFixedHeight) {
+        const scrollableTbody = tableRef.current.querySelector(
+          '.rt-tbody'
+        ) as HTMLDivElement
+        if (scrollableTbody) {
+          scrollableTbody.scrollTo(0, 0)
+        }
+      } else {
+        tableRef.current.scrollIntoView()
+      }
     }
+
     if (props.onPageChange) {
       props.onPageChange(...args)
     }
   }
 
+  const heightStyle = props.height
+    ? {
+        height: `${props.height}px`,
+      }
+    : null
+
   return (
     <div ref={tableRef}>
       <ReactTable
         {...props}
+        style={heightStyle}
         onPageChange={handlePageChange}
         PaginationComponent={HKTablePagination}
       />

--- a/src/HKTableHeader.tsx
+++ b/src/HKTableHeader.tsx
@@ -18,15 +18,18 @@ const HKTableHeader: React.FunctionComponent<any> = ({
   id,
   sort,
 }: IHeaderPropTypes) => {
-  return (
-    <div className='pa2 dark-gray tl ttc b f5 flex items-center'>
-      {sort.id === id && (
+  const sortUi = sort
+    ? sort.id === id && (
         <MalibuIcon
           name={sort.desc ? 'direction-up-16' : 'direction-down-16'}
           size={16}
           extraClasses={classnames('malibu-fill-gradient-dark-gray')}
         />
-      )}
+      )
+    : null
+  return (
+    <div className='pa2 dark-gray tl ttc b f5 flex items-center'>
+      {sortUi}
       {label}
     </div>
   )

--- a/stories/HKTable.stories.tsx
+++ b/stories/HKTable.stories.tsx
@@ -40,3 +40,11 @@ storiesOf('HKTable', module)
   .add(`With Pagination`, () => (
     <HKTable showPagination={true} columns={columns} data={paginatedData} />
   ))
+  .add(`Fixed Height With Pagination`, () => (
+    <HKTable
+      height={400}
+      showPagination={true}
+      columns={columns}
+      data={paginatedData}
+    />
+  ))

--- a/stories/HKTableHeader.stories.tsx
+++ b/stories/HKTableHeader.stories.tsx
@@ -1,14 +1,7 @@
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 
-import {
-  default as HKTableHeader,
-} from '../src/HKTableHeader'
-
-const unsorted = {
-  desc: true,
-  id: 'another-one',
-}
+import { default as HKTableHeader } from '../src/HKTableHeader'
 
 const desc = {
   desc: true,
@@ -21,12 +14,6 @@ const asc = {
 }
 
 storiesOf('HKTableHeader', module)
-  .add(`Unsorted`, () => (
-    <HKTableHeader label='Title' id='title' sort={unsorted} />
-  ))
-  .add(`Desc`, () => (
-    <HKTableHeader label='Title' id='title' sort={desc} />
-  ))
-  .add(`Asc`, () => (
-    <HKTableHeader label='Title' id='title' sort={asc} />
-  ))
+  .add(`Unsorted`, () => <HKTableHeader label='Title' id='title' />)
+  .add(`Desc`, () => <HKTableHeader label='Title' id='title' sort={desc} />)
+  .add(`Asc`, () => <HKTableHeader label='Title' id='title' sort={asc} />)

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -5399,6 +5399,1093 @@ exports[`Storyshots HKModal/initially open with confirmation 1`] = `
 </div>
 `;
 
+exports[`Storyshots HKTable Fixed Height With Pagination 1`] = `
+<div>
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <div>
+    <div
+      className="ReactTable"
+      style={
+        Object {
+          "height": "400px",
+        }
+      }
+    >
+      <div
+        className="rt-table"
+        role="grid"
+        style={undefined}
+      >
+        <div
+          className="rt-thead -header"
+          style={
+            Object {
+              "minWidth": "200px",
+            }
+          }
+        >
+          <div
+            className="rt-tr"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-th rt-resizable-header -cursor-pointer"
+              onClick={[Function]}
+              role="columnheader"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+              tabIndex="-1"
+            >
+              <div
+                className="rt-resizable-header-content"
+              >
+                <div
+                  className="pa2 dark-gray tl ttc b f5 flex items-center"
+                >
+                  <svg
+                    className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                    style={
+                      Object {
+                        "height": "16px",
+                        "width": "16px",
+                      }
+                    }
+                  >
+                    <use
+                      xlinkHref="#direction-down-16"
+                    />
+                  </svg>
+                  Name
+                </div>
+              </div>
+              <div
+                className="rt-resizer"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              />
+            </div>
+            <div
+              className="rt-th rt-resizable-header -cursor-pointer"
+              onClick={[Function]}
+              role="columnheader"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+              tabIndex="-1"
+            >
+              <div
+                className="rt-resizable-header-content"
+              >
+                <div
+                  className="pa2 dark-gray tl ttc b f5 flex items-center"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                className="rt-resizer"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tbody"
+          style={
+            Object {
+              "minWidth": "200px",
+            }
+          }
+        >
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pagination-bottom"
+      >
+        <div
+          className="pv4 ph3 mw8 center"
+        >
+          <div
+            className="flex items-center justify-between"
+          >
+            <button
+              className="hk-button--disabled-tertiary"
+              disabled={true}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              Previous
+               
+            </button>
+            <div
+              className="purple"
+            >
+              <button
+                className="hk-button--tertiary bg-lightest-purple"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                1
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                2
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                3
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                4
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                5
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                6
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                7
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                8
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                9
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                10
+                 
+              </button>
+            </div>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              Next
+              <svg
+                className="malibu-fill-gradient-purple ml1"
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#direction-right-28"
+                />
+              </svg>
+               
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="-loading"
+      >
+        <div
+          className="-loading-inner"
+        >
+          Loading...
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots HKTable With Pagination 1`] = `
 <div>
   <span


### PR DESCRIPTION
A tale of two commits...

7d8087c does the following:

1. Fixes https://github.com/heroku/react-hk-components/issues/69, where if you have a paginated, fixed-height table, the table won't scroll to the top upon changing pages.
2. Exposes a `height` prop on `HKTable` to make it easier for consumers to create a fixed height table<sup>1</sup>

3260257 does the following:
1. Fixes https://github.com/heroku/react-hk-components/issues/70
2. Checks whether the `sort` prop is truthy in order to conditionally render our lovely up or down arrow (depending on the sort value). This was causing issues on the consumer side where, if you omitted the `sort` prop altogether when using `HKTableHeader`, you would get a nasty javascript error (`id` property doesn't exist on null, blah blah)

-- 
1. As best as I can tell, the only mechanism we can use to determine whether the table is fixed-height or not is whether the `ReactTable` div has an inline-style added to it at runtime. Since we need this data point when we're figuring out what to do `onPageChange`, the simplest solution I could come up with was to check whether a `height` prop had been passed to this instance of `HKTable`. Otherwise, we would have to do some weird, manual DOM inspection (e.g., `node.hasAttribute("style")` etc).