### PR TITLE
Include Salesforce Sans

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,11 +1,4 @@
-<link
-  rel="stylesheet"
-  href="https://www.herokucdn.com/purple3/latest/purple3.min.css"
-/>
 <style>
-  body {
-    padding: 2em;
-  }
   @font-face {
     font-family: 'Salesforce Sans';
     font-style: 'normal';


### PR DESCRIPTION
Includes the `Salesforce Sans` font-family so that our UI doesn't show up in Times New Roman 😛 .

Hitherto, my browser had been loading a system copy of Salesforce Sans, which meant that I wasn't able to observe this issue.