### PR TITLE
Less Restrictive Height Prop for HKTable

### DIFF
--- a/src/HKTable.tsx
+++ b/src/HKTable.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import ReactTable from 'react-table'
 import './static/styles/table.css'
+import classnames from 'classnames'
 
 import { default as HKTablePagination } from './HKTablePagination'
 
 const HKTable: React.FunctionComponent<any> = props => {
-  const tableRef = React.createRef<HTMLDivElement>()
+  let tableRef = React.createRef<HTMLDivElement>()
 
   const handlePageChange = (...args) => {
     if (tableRef.current) {
@@ -33,15 +34,28 @@ const HKTable: React.FunctionComponent<any> = props => {
       }
     : null
 
+  const tableStyle = {
+    ...props.style,
+    ...heightStyle,
+  }
+
   return (
-    <div ref={tableRef}>
-      <ReactTable
-        {...props}
-        style={heightStyle}
-        onPageChange={handlePageChange}
-        PaginationComponent={HKTablePagination}
-      />
-    </div>
+    <ReactTable
+      {...props}
+      style={tableStyle}
+      onPageChange={handlePageChange}
+      PaginationComponent={HKTablePagination}
+      TableComponent={({ children, className, ...rest }) => (
+        <div
+          ref={tableRef}
+          className={classnames('rt-table', className)}
+          role='grid'
+          {...rest}
+        >
+          {children}
+        </div>
+      )}
+    />
   )
 }
 

--- a/src/HKTable.tsx
+++ b/src/HKTable.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
+import classnames from 'classnames'
+import React from 'react'
 import ReactTable from 'react-table'
 import './static/styles/table.css'
-import classnames from 'classnames'
 
 import { default as HKTablePagination } from './HKTablePagination'
 
 const HKTable: React.FunctionComponent<any> = props => {
-  let tableRef = React.createRef<HTMLDivElement>()
+  const tableRef = React.createRef<HTMLDivElement>()
 
   const handlePageChange = (...args) => {
     if (tableRef.current) {

--- a/src/HKTable.tsx
+++ b/src/HKTable.tsx
@@ -29,7 +29,7 @@ const HKTable: React.FunctionComponent<any> = props => {
 
   const heightStyle = props.height
     ? {
-        height: `${props.height}px`,
+        height: `${props.height}`,
       }
     : null
 

--- a/src/HKTable.tsx
+++ b/src/HKTable.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import React from 'react'
+import * as React from 'react'
 import ReactTable from 'react-table'
 import './static/styles/table.css'
 

--- a/src/HKTablePagination.tsx
+++ b/src/HKTablePagination.tsx
@@ -56,7 +56,7 @@ const HKTablePagination: React.FunctionComponent<any> = (
   }
 
   return (
-    <div className='pv4 ph3 mw8 center'>
+    <div className='pv2 ph2 mw8 center'>
       <div className='flex items-center justify-between'>
         <HKButton
           type={Type.Tertiary}

--- a/src/static/styles/table.css
+++ b/src/static/styles/table.css
@@ -5,7 +5,7 @@
 }
 
 .ReactTable * {
-  box-sizing: border-box
+  box-sizing: border-box;
 }
 
 .ReactTable .rt-table {
@@ -15,7 +15,7 @@
   align-items: stretch;
   width: 100%;
   border-collapse: collapse;
-  overflow: auto
+  overflow: auto;
 }
 
 .ReactTable .rt-thead {
@@ -27,7 +27,7 @@
 
 .ReactTable .rt-thead.-headerGroups {
   background: rgba(0, 0, 0, 0.03);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05)
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 .ReactTable .rt-thead.-filters {
@@ -42,11 +42,11 @@
   font-size: inherit;
   border-radius: 3px;
   font-weight: normal;
-  outline: none
+  outline: none;
 }
 
 .ReactTable .rt-thead.-filters .rt-th {
-  border-right: 1px solid rgba(0, 0, 0, 0.02)
+  border-right: 1px solid rgba(0, 0, 0, 0.02);
 }
 
 .ReactTable .rt-thead.-header {
@@ -55,7 +55,7 @@
 }
 
 .ReactTable .rt-thead .rt-tr {
-  text-align: center
+  text-align: center;
 }
 
 .ReactTable .rt-thead .rt-th:focus {
@@ -64,32 +64,24 @@
 
 .ReactTable .rt-thead .rt-th,
 .ReactTable .rt-thead .rt-td {
-  // padding: 5px 5px;
   line-height: normal;
   position: relative;
-  // border-right: 1px solid rgba(0, 0, 0, 0.05);
-  transition: box-shadow .3s cubic-bezier(.175, .885, .32, 1.275);
+  transition: box-shadow 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   box-shadow: inset 0 0 0 0 transparent;
 }
 
-.ReactTable .rt-thead .rt-th.-sort-asc,
-.ReactTable .rt-thead .rt-td.-sort-asc {
-  // box-shadow: inset 0 3px 0 0 rgba(0, 0, 0, 0.6)
-}
-
-.ReactTable .rt-thead .rt-th.-sort-desc,
-.ReactTable .rt-thead .rt-td.-sort-desc {
-  // box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.6)
+.ReactTable .pagination-bottom {
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 .ReactTable .rt-thead .rt-th.-cursor-pointer,
 .ReactTable .rt-thead .rt-td.-cursor-pointer {
-  cursor: pointer
+  cursor: pointer;
 }
 
 .ReactTable .rt-thead .rt-th:last-child,
 .ReactTable .rt-thead .rt-td:last-child {
-  border-right: 0
+  border-right: 0;
 }
 
 .ReactTable .rt-thead .rt-resizable-header {
@@ -97,16 +89,16 @@
 }
 
 .ReactTable .rt-thead .rt-resizable-header:last-child {
-  overflow: hidden
+  overflow: hidden;
 }
 
 .ReactTable .rt-thead .rt-resizable-header-content {
   overflow: hidden;
-  text-overflow: ellipsis
+  text-overflow: ellipsis;
 }
 
 .ReactTable .rt-thead .rt-header-pivot {
-  border-right-color: #f7f7f7
+  border-right-color: #f7f7f7;
 }
 
 .ReactTable .rt-thead .rt-header-pivot:after,
@@ -114,25 +106,25 @@
   left: 100%;
   top: 50%;
   border: solid transparent;
-  content: " ";
+  content: ' ';
   height: 0;
   width: 0;
   position: absolute;
-  pointer-events: none
+  pointer-events: none;
 }
 
 .ReactTable .rt-thead .rt-header-pivot:after {
   border-color: rgba(255, 255, 255, 0);
   border-left-color: #fff;
   border-width: 8px;
-  margin-top: -8px
+  margin-top: -8px;
 }
 
 .ReactTable .rt-thead .rt-header-pivot:before {
   border-color: rgba(102, 102, 102, 0);
   border-left-color: #f7f7f7;
   border-width: 10px;
-  margin-top: -10px
+  margin-top: -10px;
 }
 
 .ReactTable .rt-tbody {
@@ -147,7 +139,7 @@
 }
 
 .ReactTable .rt-tbody .rt-tr-group:last-child {
-  border-bottom: 0
+  border-bottom: 0;
 }
 
 .ReactTable .rt-tbody .rt-td {
@@ -157,25 +149,25 @@
 }
 
 .ReactTable .rt-tbody .rt-td:last-child {
-  border-right: 0
+  border-right: 0;
 }
 
 .ReactTable .rt-tbody .rt-expandable {
   cursor: pointer;
-  text-overflow: clip
+  text-overflow: clip;
 }
 
 .ReactTable .rt-tr-group {
   flex: 1 0 auto;
   display: flex;
   flex-direction: column;
-  align-items: stretch
+  align-items: stretch;
 }
 
 .ReactTable .rt-tr {
   flex: 1 0 auto;
   cursor: pointer;
-  display: inline-flex
+  display: inline-flex;
 }
 
 .ReactTable .rt-th,
@@ -186,7 +178,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  transition: .3s ease;
+  transition: 0.3s ease;
   transition-property: width, min-width, padding, opacity;
 }
 
@@ -196,7 +188,7 @@
   min-width: 0 !important;
   padding: 0 !important;
   border: 0 !important;
-  opacity: 0 !important
+  opacity: 0 !important;
 }
 
 .ReactTable .rt-expander {
@@ -218,12 +210,12 @@
   border-left: 5.04px solid transparent;
   border-right: 5.04px solid transparent;
   border-top: 7px solid rgba(0, 0, 0, 0.8);
-  transition: all .3s cubic-bezier(.175, .885, .32, 1.275);
-  cursor: pointer
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  cursor: pointer;
 }
 
 .ReactTable .rt-expander.-open:after {
-  transform: translate(-50%, -50%) rotate(0)
+  transform: translate(-50%, -50%) rotate(0);
 }
 
 .ReactTable .rt-resizer {
@@ -234,7 +226,7 @@
   bottom: 0;
   right: -18px;
   cursor: col-resize;
-  z-index: 10
+  z-index: 10;
 }
 
 .ReactTable .rt-tfoot {
@@ -249,11 +241,11 @@
 }
 
 .ReactTable .rt-tfoot .rt-td:last-child {
-  border-right: 0
+  border-right: 0;
 }
 
 .ReactTable.-striped .rt-tr.-odd {
-  background: rgba(0, 0, 0, 0.03)
+  background: rgba(0, 0, 0, 0.03);
 }
 
 .ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {
@@ -279,7 +271,7 @@
   font-size: inherit;
   border-radius: 3px;
   font-weight: normal;
-  outline: none
+  outline: none;
 }
 
 .ReactTable .-pagination .-btn {
@@ -293,25 +285,25 @@
   font-size: 1em;
   color: rgba(0, 0, 0, 0.6);
   background: rgba(0, 0, 0, 0.1);
-  transition: all .1s ease;
+  transition: all 0.1s ease;
   cursor: pointer;
   outline: none;
 }
 
 .ReactTable .-pagination .-btn[disabled] {
-  opacity: .5;
-  cursor: default
+  opacity: 0.5;
+  cursor: default;
 }
 
 .ReactTable .-pagination .-btn:not([disabled]):hover {
   background: rgba(0, 0, 0, 0.3);
-  color: #fff
+  color: #fff;
 }
 
 .ReactTable .-pagination .-previous,
 .ReactTable .-pagination .-next {
   flex: 1;
-  text-align: center
+  text-align: center;
 }
 
 .ReactTable .-pagination .-center {
@@ -324,13 +316,13 @@
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: space-around
+  justify-content: space-around;
 }
 
 .ReactTable .-pagination .-pageInfo {
   display: inline-block;
   margin: 3px 10px;
-  white-space: nowrap
+  white-space: nowrap;
 }
 
 .ReactTable .-pagination .-pageJump {
@@ -339,11 +331,11 @@
 
 .ReactTable .-pagination .-pageJump input {
   width: 70px;
-  text-align: center
+  text-align: center;
 }
 
 .ReactTable .-pagination .-pageSizeOptions {
-  margin: 3px 10px
+  margin: 3px 10px;
 }
 
 .ReactTable .rt-noData {
@@ -353,11 +345,11 @@
   top: 50%;
   transform: translate(-50%, -50%);
   background: rgba(255, 255, 255, 0.8);
-  transition: all .3s ease;
+  transition: all 0.3s ease;
   z-index: 1;
   pointer-events: none;
   padding: 20px;
-  color: rgba(0, 0, 0, 0.5)
+  color: rgba(0, 0, 0, 0.5);
 }
 
 .ReactTable .-loading {
@@ -368,7 +360,7 @@
   top: 0;
   bottom: 0;
   background: rgba(255, 255, 255, 0.8);
-  transition: all .3s ease;
+  transition: all 0.3s ease;
   z-index: -1;
   opacity: 0;
   pointer-events: none;
@@ -384,7 +376,7 @@
   font-size: 15px;
   color: rgba(0, 0, 0, 0.6);
   transform: translateY(-52%);
-  transition: all .3s cubic-bezier(.25, .46, .45, .94)
+  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 .ReactTable .-loading.-active {
@@ -394,12 +386,12 @@
 }
 
 .ReactTable .-loading.-active > div {
-  transform: translateY(50%)
+  transform: translateY(50%);
 }
 
 .ReactTable .rt-resizing .rt-th,
 .ReactTable .rt-resizing .rt-td {
   transition: none !important;
   cursor: col-resize;
-  user-select: none
+  user-select: none;
 }

--- a/stories/HKTable.stories.tsx
+++ b/stories/HKTable.stories.tsx
@@ -69,6 +69,18 @@ storiesOf('HKTable', module)
       data={paginatedData}
     />
   ))
+  .add(`Fixed Height (px) With Pagination and Custom Style`, () => (
+    <HKTable
+      style={{
+        background: 'red',
+        maxHeight: 200,
+      }}
+      showPagination={true}
+      columns={columns}
+      onSortedChange={handleSortChange}
+      data={paginatedData}
+    />
+  ))
   .add(`Fixed Height (vh) With Pagination`, () => (
     <HKTable
       height={'100vh'}

--- a/stories/HKTable.stories.tsx
+++ b/stories/HKTable.stories.tsx
@@ -60,9 +60,18 @@ storiesOf('HKTable', module)
       data={paginatedData}
     />
   ))
-  .add(`Fixed Height With Pagination`, () => (
+  .add(`Fixed Height (px) With Pagination`, () => (
     <HKTable
-      height={400}
+      height={'400px'}
+      showPagination={true}
+      columns={columns}
+      onSortedChange={handleSortChange}
+      data={paginatedData}
+    />
+  ))
+  .add(`Fixed Height (vh) With Pagination`, () => (
+    <HKTable
+      height={'100vh'}
       showPagination={true}
       columns={columns}
       onSortedChange={handleSortChange}

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -5411,1059 +5411,949 @@ exports[`Storyshots HKTable Fixed Height (px) With Pagination 1`] = `
     dangerouslySetInnerHTML={undefined}
     style={undefined}
   />
-  <div>
-    <div
-      className="ReactTable"
-      style={
-        Object {
-          "height": "400px",
-        }
+  <div
+    className="ReactTable"
+    style={
+      Object {
+        "height": "400px",
       }
+    }
+  >
+    <div
+      className="rt-table"
+      role="grid"
+      style={undefined}
     >
       <div
-        className="rt-table"
-        role="grid"
-        style={undefined}
+        className="rt-thead -header"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="rt-thead -header"
-          style={
-            Object {
-              "minWidth": "200px",
-            }
-          }
+          className="rt-tr"
+          role="row"
+          style={undefined}
         >
           <div
-            className="rt-tr"
-            role="row"
-            style={undefined}
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
+            }
+            tabIndex="-1"
           >
             <div
-              className="rt-th rt-resizable-header -cursor-pointer"
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
-              tabIndex="-1"
+              className="rt-resizable-header-content"
             >
               <div
-                className="rt-resizable-header-content"
+                className="pa2 dark-gray ttc b f5 flex items-center"
               >
-                <div
-                  className="pa2 dark-gray ttc b f5 flex items-center"
-                >
-                  <svg
-                    className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
-                    style={
-                      Object {
-                        "height": "16px",
-                        "width": "16px",
-                      }
+                <svg
+                  className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                  style={
+                    Object {
+                      "height": "16px",
+                      "width": "16px",
                     }
-                  >
-                    <use
-                      xlinkHref="#direction-down-16"
-                    />
-                  </svg>
-                  Name
-                </div>
-              </div>
-              <div
-                className="rt-resizer"
-                onMouseDown={[Function]}
-                onTouchStart={[Function]}
-              />
-            </div>
-            <div
-              className="rt-th rt-resizable-header -cursor-pointer"
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
-              tabIndex="-1"
-            >
-              <div
-                className="rt-resizable-header-content"
-              >
-                <div
-                  className="pa2 dark-gray ttc b f5 flex items-center justify-end"
+                  }
                 >
-                  Age
-                </div>
+                  <use
+                    xlinkHref="#direction-down-16"
+                  />
+                </svg>
+                Name
               </div>
-              <div
-                className="rt-resizer"
-                onMouseDown={[Function]}
-                onTouchStart={[Function]}
-              />
             </div>
+            <div
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
-        </div>
-        <div
-          className="rt-tbody"
-          style={
-            Object {
-              "minWidth": "200px",
+          <div
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
             }
-          }
-        >
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
+            tabIndex="-1"
           >
             <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
+              className="rt-resizable-header-content"
             >
               <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
+                className="pa2 dark-gray ttc b f5 flex items-center justify-end"
               >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
+                Age
               </div>
             </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
             <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
         </div>
       </div>
       <div
-        className="pagination-bottom"
+        className="rt-tbody"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="pv4 ph3 mw8 center"
+          className="rt-tr-group"
+          role="rowgroup"
         >
           <div
-            className="flex items-center justify-between"
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pagination-bottom"
+    >
+      <div
+        className="pv2 ph2 mw8 center"
+      >
+        <div
+          className="flex items-center justify-between"
+        >
+          <button
+            className="hk-button--disabled-tertiary"
+            disabled={true}
+            onClick={[Function]}
+            title={undefined}
+            type="button"
+            value={undefined}
+          >
+             
+            Previous
+             
+          </button>
+          <div
+            className="purple"
           >
             <button
-              className="hk-button--disabled-tertiary"
-              disabled={true}
+              className="hk-button--tertiary bg-lightest-purple"
+              disabled={false}
               onClick={[Function]}
               title={undefined}
               type="button"
               value={undefined}
             >
                
-              Previous
+              1
                
             </button>
-            <div
-              className="purple"
-            >
-              <button
-                className="hk-button--tertiary bg-lightest-purple"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                1
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                2
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                3
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                4
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                5
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                6
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                7
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                8
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                9
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                10
-                 
-              </button>
-            </div>
             <button
               className="hk-button--tertiary"
               disabled={false}
@@ -6473,33 +6363,1247 @@ exports[`Storyshots HKTable Fixed Height (px) With Pagination 1`] = `
               value={undefined}
             >
                
-              Next
-              <svg
-                className="malibu-fill-gradient-purple ml1"
-                style={
-                  Object {
-                    "height": "16px",
-                    "width": "16px",
-                  }
-                }
-              >
-                <use
-                  xlinkHref="#direction-right-28"
-                />
-              </svg>
+              2
                
             </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              3
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              4
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              5
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              6
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              7
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              8
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              9
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              10
+               
+            </button>
+          </div>
+          <button
+            className="hk-button--tertiary"
+            disabled={false}
+            onClick={[Function]}
+            title={undefined}
+            type="button"
+            value={undefined}
+          >
+             
+            Next
+            <svg
+              className="malibu-fill-gradient-purple ml1"
+              style={
+                Object {
+                  "height": "16px",
+                  "width": "16px",
+                }
+              }
+            >
+              <use
+                xlinkHref="#direction-right-28"
+              />
+            </svg>
+             
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="-loading"
+    >
+      <div
+        className="-loading-inner"
+      >
+        Loading...
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots HKTable Fixed Height (px) With Pagination and Custom Style 1`] = `
+<div>
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <div
+    className="ReactTable"
+    style={
+      Object {
+        "background": "red",
+        "maxHeight": 200,
+      }
+    }
+  >
+    <div
+      className="rt-table"
+      role="grid"
+      style={undefined}
+    >
+      <div
+        className="rt-thead -header"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
+      >
+        <div
+          className="rt-tr"
+          role="row"
+          style={undefined}
+        >
+          <div
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
+            }
+            tabIndex="-1"
+          >
+            <div
+              className="rt-resizable-header-content"
+            >
+              <div
+                className="pa2 dark-gray ttc b f5 flex items-center"
+              >
+                <svg
+                  className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                  style={
+                    Object {
+                      "height": "16px",
+                      "width": "16px",
+                    }
+                  }
+                >
+                  <use
+                    xlinkHref="#direction-down-16"
+                  />
+                </svg>
+                Name
+              </div>
+            </div>
+            <div
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
+          </div>
+          <div
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
+            }
+            tabIndex="-1"
+          >
+            <div
+              className="rt-resizable-header-content"
+            >
+              <div
+                className="pa2 dark-gray ttc b f5 flex items-center justify-end"
+              >
+                Age
+              </div>
+            </div>
+            <div
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
         </div>
       </div>
       <div
-        className="-loading"
+        className="rt-tbody"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="-loading-inner"
+          className="rt-tr-group"
+          role="rowgroup"
         >
-          Loading...
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
         </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pagination-bottom"
+    >
+      <div
+        className="pv2 ph2 mw8 center"
+      >
+        <div
+          className="flex items-center justify-between"
+        >
+          <button
+            className="hk-button--disabled-tertiary"
+            disabled={true}
+            onClick={[Function]}
+            title={undefined}
+            type="button"
+            value={undefined}
+          >
+             
+            Previous
+             
+          </button>
+          <div
+            className="purple"
+          >
+            <button
+              className="hk-button--tertiary bg-lightest-purple"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              1
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              2
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              3
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              4
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              5
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              6
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              7
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              8
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              9
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              10
+               
+            </button>
+          </div>
+          <button
+            className="hk-button--tertiary"
+            disabled={false}
+            onClick={[Function]}
+            title={undefined}
+            type="button"
+            value={undefined}
+          >
+             
+            Next
+            <svg
+              className="malibu-fill-gradient-purple ml1"
+              style={
+                Object {
+                  "height": "16px",
+                  "width": "16px",
+                }
+              }
+            >
+              <use
+                xlinkHref="#direction-right-28"
+              />
+            </svg>
+             
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="-loading"
+    >
+      <div
+        className="-loading-inner"
+      >
+        Loading...
       </div>
     </div>
   </div>
@@ -6518,1059 +7622,949 @@ exports[`Storyshots HKTable Fixed Height (vh) With Pagination 1`] = `
     dangerouslySetInnerHTML={undefined}
     style={undefined}
   />
-  <div>
-    <div
-      className="ReactTable"
-      style={
-        Object {
-          "height": "100vh",
-        }
+  <div
+    className="ReactTable"
+    style={
+      Object {
+        "height": "100vh",
       }
+    }
+  >
+    <div
+      className="rt-table"
+      role="grid"
+      style={undefined}
     >
       <div
-        className="rt-table"
-        role="grid"
-        style={undefined}
+        className="rt-thead -header"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="rt-thead -header"
-          style={
-            Object {
-              "minWidth": "200px",
-            }
-          }
+          className="rt-tr"
+          role="row"
+          style={undefined}
         >
           <div
-            className="rt-tr"
-            role="row"
-            style={undefined}
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
+            }
+            tabIndex="-1"
           >
             <div
-              className="rt-th rt-resizable-header -cursor-pointer"
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
-              tabIndex="-1"
+              className="rt-resizable-header-content"
             >
               <div
-                className="rt-resizable-header-content"
+                className="pa2 dark-gray ttc b f5 flex items-center"
               >
-                <div
-                  className="pa2 dark-gray ttc b f5 flex items-center"
-                >
-                  <svg
-                    className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
-                    style={
-                      Object {
-                        "height": "16px",
-                        "width": "16px",
-                      }
+                <svg
+                  className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                  style={
+                    Object {
+                      "height": "16px",
+                      "width": "16px",
                     }
-                  >
-                    <use
-                      xlinkHref="#direction-down-16"
-                    />
-                  </svg>
-                  Name
-                </div>
-              </div>
-              <div
-                className="rt-resizer"
-                onMouseDown={[Function]}
-                onTouchStart={[Function]}
-              />
-            </div>
-            <div
-              className="rt-th rt-resizable-header -cursor-pointer"
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
-              tabIndex="-1"
-            >
-              <div
-                className="rt-resizable-header-content"
-              >
-                <div
-                  className="pa2 dark-gray ttc b f5 flex items-center justify-end"
+                  }
                 >
-                  Age
-                </div>
+                  <use
+                    xlinkHref="#direction-down-16"
+                  />
+                </svg>
+                Name
               </div>
-              <div
-                className="rt-resizer"
-                onMouseDown={[Function]}
-                onTouchStart={[Function]}
-              />
             </div>
+            <div
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
-        </div>
-        <div
-          className="rt-tbody"
-          style={
-            Object {
-              "minWidth": "200px",
+          <div
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
             }
-          }
-        >
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
+            tabIndex="-1"
           >
             <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
+              className="rt-resizable-header-content"
             >
               <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
+                className="pa2 dark-gray ttc b f5 flex items-center justify-end"
               >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
+                Age
               </div>
             </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
             <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
         </div>
       </div>
       <div
-        className="pagination-bottom"
+        className="rt-tbody"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="pv4 ph3 mw8 center"
+          className="rt-tr-group"
+          role="rowgroup"
         >
           <div
-            className="flex items-center justify-between"
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pagination-bottom"
+    >
+      <div
+        className="pv2 ph2 mw8 center"
+      >
+        <div
+          className="flex items-center justify-between"
+        >
+          <button
+            className="hk-button--disabled-tertiary"
+            disabled={true}
+            onClick={[Function]}
+            title={undefined}
+            type="button"
+            value={undefined}
+          >
+             
+            Previous
+             
+          </button>
+          <div
+            className="purple"
           >
             <button
-              className="hk-button--disabled-tertiary"
-              disabled={true}
+              className="hk-button--tertiary bg-lightest-purple"
+              disabled={false}
               onClick={[Function]}
               title={undefined}
               type="button"
               value={undefined}
             >
                
-              Previous
+              1
                
             </button>
-            <div
-              className="purple"
-            >
-              <button
-                className="hk-button--tertiary bg-lightest-purple"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                1
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                2
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                3
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                4
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                5
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                6
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                7
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                8
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                9
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                10
-                 
-              </button>
-            </div>
             <button
               className="hk-button--tertiary"
               disabled={false}
@@ -7580,33 +8574,141 @@ exports[`Storyshots HKTable Fixed Height (vh) With Pagination 1`] = `
               value={undefined}
             >
                
-              Next
-              <svg
-                className="malibu-fill-gradient-purple ml1"
-                style={
-                  Object {
-                    "height": "16px",
-                    "width": "16px",
-                  }
-                }
-              >
-                <use
-                  xlinkHref="#direction-right-28"
-                />
-              </svg>
+              2
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              3
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              4
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              5
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              6
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              7
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              8
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              9
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              10
                
             </button>
           </div>
+          <button
+            className="hk-button--tertiary"
+            disabled={false}
+            onClick={[Function]}
+            title={undefined}
+            type="button"
+            value={undefined}
+          >
+             
+            Next
+            <svg
+              className="malibu-fill-gradient-purple ml1"
+              style={
+                Object {
+                  "height": "16px",
+                  "width": "16px",
+                }
+              }
+            >
+              <use
+                xlinkHref="#direction-right-28"
+              />
+            </svg>
+             
+          </button>
         </div>
       </div>
+    </div>
+    <div
+      className="-loading"
+    >
       <div
-        className="-loading"
+        className="-loading-inner"
       >
-        <div
-          className="-loading-inner"
-        >
-          Loading...
-        </div>
+        Loading...
       </div>
     </div>
   </div>
@@ -7625,1055 +8727,945 @@ exports[`Storyshots HKTable With Pagination 1`] = `
     dangerouslySetInnerHTML={undefined}
     style={undefined}
   />
-  <div>
+  <div
+    className="ReactTable"
+    style={Object {}}
+  >
     <div
-      className="ReactTable"
-      style={Object {}}
+      className="rt-table"
+      role="grid"
+      style={undefined}
     >
       <div
-        className="rt-table"
-        role="grid"
-        style={undefined}
+        className="rt-thead -header"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="rt-thead -header"
-          style={
-            Object {
-              "minWidth": "200px",
-            }
-          }
+          className="rt-tr"
+          role="row"
+          style={undefined}
         >
           <div
-            className="rt-tr"
-            role="row"
-            style={undefined}
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
+            }
+            tabIndex="-1"
           >
             <div
-              className="rt-th rt-resizable-header -cursor-pointer"
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
-              tabIndex="-1"
+              className="rt-resizable-header-content"
             >
               <div
-                className="rt-resizable-header-content"
+                className="pa2 dark-gray ttc b f5 flex items-center"
               >
-                <div
-                  className="pa2 dark-gray ttc b f5 flex items-center"
-                >
-                  <svg
-                    className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
-                    style={
-                      Object {
-                        "height": "16px",
-                        "width": "16px",
-                      }
+                <svg
+                  className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                  style={
+                    Object {
+                      "height": "16px",
+                      "width": "16px",
                     }
-                  >
-                    <use
-                      xlinkHref="#direction-down-16"
-                    />
-                  </svg>
-                  Name
-                </div>
-              </div>
-              <div
-                className="rt-resizer"
-                onMouseDown={[Function]}
-                onTouchStart={[Function]}
-              />
-            </div>
-            <div
-              className="rt-th rt-resizable-header -cursor-pointer"
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
-              tabIndex="-1"
-            >
-              <div
-                className="rt-resizable-header-content"
-              >
-                <div
-                  className="pa2 dark-gray ttc b f5 flex items-center justify-end"
+                  }
                 >
-                  Age
-                </div>
+                  <use
+                    xlinkHref="#direction-down-16"
+                  />
+                </svg>
+                Name
               </div>
-              <div
-                className="rt-resizer"
-                onMouseDown={[Function]}
-                onTouchStart={[Function]}
-              />
             </div>
+            <div
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
-        </div>
-        <div
-          className="rt-tbody"
-          style={
-            Object {
-              "minWidth": "200px",
+          <div
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
             }
-          }
-        >
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
+            tabIndex="-1"
           >
             <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
+              className="rt-resizable-header-content"
             >
               <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
+                className="pa2 dark-gray ttc b f5 flex items-center justify-end"
               >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
+                Age
               </div>
             </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
             <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -even"
-              role="row"
-              style={undefined}
-            >
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                Matt Rothenberg
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                18
-              </div>
-            </div>
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
         </div>
       </div>
       <div
-        className="pagination-bottom"
+        className="rt-tbody"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="pv4 ph3 mw8 center"
+          className="rt-tr-group"
+          role="rowgroup"
         >
           <div
-            className="flex items-center justify-between"
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -even"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Matt Rothenberg
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              18
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="pagination-bottom"
+    >
+      <div
+        className="pv2 ph2 mw8 center"
+      >
+        <div
+          className="flex items-center justify-between"
+        >
+          <button
+            className="hk-button--disabled-tertiary"
+            disabled={true}
+            onClick={[Function]}
+            title={undefined}
+            type="button"
+            value={undefined}
+          >
+             
+            Previous
+             
+          </button>
+          <div
+            className="purple"
           >
             <button
-              className="hk-button--disabled-tertiary"
-              disabled={true}
+              className="hk-button--tertiary bg-lightest-purple"
+              disabled={false}
               onClick={[Function]}
               title={undefined}
               type="button"
               value={undefined}
             >
                
-              Previous
+              1
                
             </button>
-            <div
-              className="purple"
-            >
-              <button
-                className="hk-button--tertiary bg-lightest-purple"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                1
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                2
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                3
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                4
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                5
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                6
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                7
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                8
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                9
-                 
-              </button>
-              <button
-                className="hk-button--tertiary"
-                disabled={false}
-                onClick={[Function]}
-                title={undefined}
-                type="button"
-                value={undefined}
-              >
-                 
-                10
-                 
-              </button>
-            </div>
             <button
               className="hk-button--tertiary"
               disabled={false}
@@ -8683,33 +9675,141 @@ exports[`Storyshots HKTable With Pagination 1`] = `
               value={undefined}
             >
                
-              Next
-              <svg
-                className="malibu-fill-gradient-purple ml1"
-                style={
-                  Object {
-                    "height": "16px",
-                    "width": "16px",
-                  }
-                }
-              >
-                <use
-                  xlinkHref="#direction-right-28"
-                />
-              </svg>
+              2
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              3
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              4
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              5
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              6
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              7
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              8
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              9
+               
+            </button>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              10
                
             </button>
           </div>
+          <button
+            className="hk-button--tertiary"
+            disabled={false}
+            onClick={[Function]}
+            title={undefined}
+            type="button"
+            value={undefined}
+          >
+             
+            Next
+            <svg
+              className="malibu-fill-gradient-purple ml1"
+              style={
+                Object {
+                  "height": "16px",
+                  "width": "16px",
+                }
+              }
+            >
+              <use
+                xlinkHref="#direction-right-28"
+              />
+            </svg>
+             
+          </button>
         </div>
       </div>
+    </div>
+    <div
+      className="-loading"
+    >
       <div
-        className="-loading"
+        className="-loading-inner"
       >
-        <div
-          className="-loading-inner"
-        >
-          Loading...
-        </div>
+        Loading...
       </div>
     </div>
   </div>
@@ -8728,956 +9828,954 @@ exports[`Storyshots HKTable Without Pagination 1`] = `
     dangerouslySetInnerHTML={undefined}
     style={undefined}
   />
-  <div>
+  <div
+    className="ReactTable"
+    style={Object {}}
+  >
     <div
-      className="ReactTable"
-      style={Object {}}
+      className="rt-table"
+      role="grid"
+      style={undefined}
     >
       <div
-        className="rt-table"
-        role="grid"
-        style={undefined}
+        className="rt-thead -header"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="rt-thead -header"
-          style={
-            Object {
-              "minWidth": "200px",
-            }
-          }
+          className="rt-tr"
+          role="row"
+          style={undefined}
         >
           <div
-            className="rt-tr"
-            role="row"
-            style={undefined}
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
+            }
+            tabIndex="-1"
           >
             <div
-              className="rt-th rt-resizable-header -cursor-pointer"
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
-              tabIndex="-1"
+              className="rt-resizable-header-content"
             >
               <div
-                className="rt-resizable-header-content"
+                className="pa2 dark-gray ttc b f5 flex items-center"
               >
-                <div
-                  className="pa2 dark-gray ttc b f5 flex items-center"
-                >
-                  <svg
-                    className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
-                    style={
-                      Object {
-                        "height": "16px",
-                        "width": "16px",
-                      }
+                <svg
+                  className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                  style={
+                    Object {
+                      "height": "16px",
+                      "width": "16px",
                     }
-                  >
-                    <use
-                      xlinkHref="#direction-down-16"
-                    />
-                  </svg>
-                  Name
-                </div>
-              </div>
-              <div
-                className="rt-resizer"
-                onMouseDown={[Function]}
-                onTouchStart={[Function]}
-              />
-            </div>
-            <div
-              className="rt-th rt-resizable-header -cursor-pointer"
-              onClick={[Function]}
-              role="columnheader"
-              style={
-                Object {
-                  "flex": "100 0 auto",
-                  "maxWidth": null,
-                  "width": "100px",
-                }
-              }
-              tabIndex="-1"
-            >
-              <div
-                className="rt-resizable-header-content"
-              >
-                <div
-                  className="pa2 dark-gray ttc b f5 flex items-center justify-end"
+                  }
                 >
-                  Age
-                </div>
+                  <use
+                    xlinkHref="#direction-down-16"
+                  />
+                </svg>
+                Name
               </div>
-              <div
-                className="rt-resizer"
-                onMouseDown={[Function]}
-                onTouchStart={[Function]}
-              />
             </div>
+            <div
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
-        </div>
-        <div
-          className="rt-tbody"
-          style={
-            Object {
-              "minWidth": "200px",
+          <div
+            className="rt-th rt-resizable-header -cursor-pointer"
+            onClick={[Function]}
+            role="columnheader"
+            style={
+              Object {
+                "flex": "100 0 auto",
+                "maxWidth": null,
+                "width": "100px",
+              }
             }
-          }
-        >
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
+            tabIndex="-1"
           >
             <div
-              className="rt-tr -odd"
-              role="row"
-              style={undefined}
+              className="rt-resizable-header-content"
             >
               <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
+                className="pa2 dark-gray ttc b f5 flex items-center justify-end"
               >
-                Tanner Linsley
-              </div>
-              <div
-                className="rt-td"
-                onClick={[Function]}
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                26
+                Age
               </div>
             </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
             <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -odd"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            className="rt-tr-group"
-            role="rowgroup"
-          >
-            <div
-              className="rt-tr -padRow -even"
-              role="row"
-              style={Object {}}
-            >
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-              <div
-                className="rt-td"
-                role="gridcell"
-                style={
-                  Object {
-                    "flex": "100 0 auto",
-                    "justifyContent": "flex-end",
-                    "maxWidth": null,
-                    "width": "100px",
-                  }
-                }
-              >
-                <span>
-                   
-                </span>
-              </div>
-            </div>
+              className="rt-resizer"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            />
           </div>
         </div>
       </div>
       <div
-        className="-loading"
+        className="rt-tbody"
+        style={
+          Object {
+            "minWidth": "200px",
+          }
+        }
       >
         <div
-          className="-loading-inner"
+          className="rt-tr-group"
+          role="rowgroup"
         >
-          Loading...
+          <div
+            className="rt-tr -odd"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              Tanner Linsley
+            </div>
+            <div
+              className="rt-td"
+              onClick={[Function]}
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              26
+            </div>
+          </div>
         </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -odd"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tr-group"
+          role="rowgroup"
+        >
+          <div
+            className="rt-tr -padRow -even"
+            role="row"
+            style={Object {}}
+          >
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+            <div
+              className="rt-td"
+              role="gridcell"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "justifyContent": "flex-end",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+            >
+              <span>
+                 
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="-loading"
+    >
+      <div
+        className="-loading-inner"
+      >
+        Loading...
       </div>
     </div>
   </div>
@@ -9816,7 +10914,7 @@ exports[`Storyshots HKTablePagination beginning 1`] = `
     style={undefined}
   />
   <div
-    className="pv4 ph3 mw8 center"
+    className="pv2 ph2 mw8 center"
   >
     <div
       className="flex items-center justify-between"
@@ -10000,7 +11098,7 @@ exports[`Storyshots HKTablePagination end 1`] = `
     style={undefined}
   />
   <div
-    className="pv4 ph3 mw8 center"
+    className="pv2 ph2 mw8 center"
   >
     <div
       className="flex items-center justify-between"
@@ -10184,7 +11282,7 @@ exports[`Storyshots HKTablePagination middle 1`] = `
     style={undefined}
   />
   <div
-    className="pv4 ph3 mw8 center"
+    className="pv2 ph2 mw8 center"
   >
     <div
       className="flex items-center justify-between"

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -5399,7 +5399,7 @@ exports[`Storyshots HKModal/initially open with confirmation 1`] = `
 </div>
 `;
 
-exports[`Storyshots HKTable Fixed Height With Pagination 1`] = `
+exports[`Storyshots HKTable Fixed Height (px) With Pagination 1`] = `
 <div>
   <span
     className="isvg loading"
@@ -5417,6 +5417,1113 @@ exports[`Storyshots HKTable Fixed Height With Pagination 1`] = `
       style={
         Object {
           "height": "400px",
+        }
+      }
+    >
+      <div
+        className="rt-table"
+        role="grid"
+        style={undefined}
+      >
+        <div
+          className="rt-thead -header"
+          style={
+            Object {
+              "minWidth": "200px",
+            }
+          }
+        >
+          <div
+            className="rt-tr"
+            role="row"
+            style={undefined}
+          >
+            <div
+              className="rt-th rt-resizable-header -cursor-pointer"
+              onClick={[Function]}
+              role="columnheader"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+              tabIndex="-1"
+            >
+              <div
+                className="rt-resizable-header-content"
+              >
+                <div
+                  className="pa2 dark-gray ttc b f5 flex items-center"
+                >
+                  <svg
+                    className="malibu-fill-gradient-purple malibu-fill-gradient-dark-gray"
+                    style={
+                      Object {
+                        "height": "16px",
+                        "width": "16px",
+                      }
+                    }
+                  >
+                    <use
+                      xlinkHref="#direction-down-16"
+                    />
+                  </svg>
+                  Name
+                </div>
+              </div>
+              <div
+                className="rt-resizer"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              />
+            </div>
+            <div
+              className="rt-th rt-resizable-header -cursor-pointer"
+              onClick={[Function]}
+              role="columnheader"
+              style={
+                Object {
+                  "flex": "100 0 auto",
+                  "maxWidth": null,
+                  "width": "100px",
+                }
+              }
+              tabIndex="-1"
+            >
+              <div
+                className="rt-resizable-header-content"
+              >
+                <div
+                  className="pa2 dark-gray ttc b f5 flex items-center justify-end"
+                >
+                  Age
+                </div>
+              </div>
+              <div
+                className="rt-resizer"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="rt-tbody"
+          style={
+            Object {
+              "minWidth": "200px",
+            }
+          }
+        >
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -odd"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+          <div
+            className="rt-tr-group"
+            role="rowgroup"
+          >
+            <div
+              className="rt-tr -even"
+              role="row"
+              style={undefined}
+            >
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                Matt Rothenberg
+              </div>
+              <div
+                className="rt-td"
+                onClick={[Function]}
+                role="gridcell"
+                style={
+                  Object {
+                    "flex": "100 0 auto",
+                    "justifyContent": "flex-end",
+                    "maxWidth": null,
+                    "width": "100px",
+                  }
+                }
+              >
+                18
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pagination-bottom"
+      >
+        <div
+          className="pv4 ph3 mw8 center"
+        >
+          <div
+            className="flex items-center justify-between"
+          >
+            <button
+              className="hk-button--disabled-tertiary"
+              disabled={true}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              Previous
+               
+            </button>
+            <div
+              className="purple"
+            >
+              <button
+                className="hk-button--tertiary bg-lightest-purple"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                1
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                2
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                3
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                4
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                5
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                6
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                7
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                8
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                9
+                 
+              </button>
+              <button
+                className="hk-button--tertiary"
+                disabled={false}
+                onClick={[Function]}
+                title={undefined}
+                type="button"
+                value={undefined}
+              >
+                 
+                10
+                 
+              </button>
+            </div>
+            <button
+              className="hk-button--tertiary"
+              disabled={false}
+              onClick={[Function]}
+              title={undefined}
+              type="button"
+              value={undefined}
+            >
+               
+              Next
+              <svg
+                className="malibu-fill-gradient-purple ml1"
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <use
+                  xlinkHref="#direction-right-28"
+                />
+              </svg>
+               
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="-loading"
+      >
+        <div
+          className="-loading-inner"
+        >
+          Loading...
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots HKTable Fixed Height (vh) With Pagination 1`] = `
+<div>
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <div>
+    <div
+      className="ReactTable"
+      style={
+        Object {
+          "height": "100vh",
         }
       }
     >


### PR DESCRIPTION
### Context
In tinkering with `DataclipResultTable` on DHC, I ran into a scenario where I needed to pass a `100vh` height value to `HKTable`. Unfortunately, at the moment, `HKTable` can only take an integer value as a `height` prop (since it translates that integer to `px` internally). Hooray short-sighted design decisions!

https://github.com/heroku/react-hk-components/commit/592be4ca349999b541076c0a3346437ade123fe1#diff-73e9e699d8863b63a0848d9e09605617L32

### The Change
Remove the `px` translation altogether, thereby allowing consumers to pass any valid CSS value as the `height` prop. For example,

```jsx
<HKTable
      height={'400px'}
      showPagination={true}
      columns={columns}
      onSortedChange={handleSortChange}
      data={paginatedData}
    />
```

```jsx
<HKTable
      height={'100vh'}
      showPagination={true}
      columns={columns}
      onSortedChange={handleSortChange}
      data={paginatedData}
    />
```