### PR TITLE
Make HKDropdown behave more like HKButton

### DIFF
--- a/src/HKDropdown.tsx
+++ b/src/HKDropdown.tsx
@@ -5,6 +5,7 @@ import OutsideClickHandler from 'react-outside-click-handler'
 import { Manager, Popper, Reference } from 'react-popper'
 
 import { default as HKButton, Type } from './HKButton'
+import { default as HKIcon } from './HKIcon'
 
 export enum Align {
   Left = 'left',
@@ -19,7 +20,9 @@ interface IDropdownProps {
   contentClassName?: string // dropdown content styling
   disabled?: boolean
   name?: string // name of the dropdown, used for testing in testID
+  small?: boolean
   title?: string
+  type?: Type
 }
 
 interface IDropdownState {
@@ -36,6 +39,8 @@ export default class HKDropdown extends React.Component<
     closeOnClick: true,
     disabled: false,
     name: 'hkdropdown',
+    small: false,
+    type: Type.Secondary,
   }
 
   public state = {
@@ -89,12 +94,13 @@ export default class HKDropdown extends React.Component<
       contentClassName,
       disabled,
       name,
+      small,
       title,
+      type,
     } = this.props
     const { showDropdown } = this.state
     const popperPlacement =
       align === Align.Right ? 'bottom-end' : 'bottom-start'
-    const iconFillClass = disabled ? 'fill-gray' : 'fill-purple'
     return (
       <Manager>
         <Reference>
@@ -104,16 +110,15 @@ export default class HKDropdown extends React.Component<
                 onClick={this.handleDropdown}
                 data-testid={this.testId()}
                 className={classnames({ ph1: !title }, className)}
-                type={Type.Secondary}
+                type={type}
+                small={small}
                 disabled={disabled}
               >
                 {title}
-                <MalibuIcon
-                  key='icon'
+                <HKIcon
                   name='caret-16'
                   size={16}
-                  fillClass={iconFillClass}
-                  extraClasses={classnames({ pl1: title })}
+                  className={classnames({ pl1: title })}
                 />
               </HKButton>
             </div>

--- a/src/HKIcon.tsx
+++ b/src/HKIcon.tsx
@@ -10,7 +10,6 @@ interface IIconProps {
 }
 
 const defaultProps = {
-  fill: Fills.Black,
   size: 16,
 }
 
@@ -22,7 +21,13 @@ const HKIcon: React.FunctionComponent<IIconProps> = ({
 }) => {
   const href = `#${name}`
   const svgClass = classNames(fill, className)
+  const currentColorDefault = !fill
+    ? {
+        fill: 'currentColor',
+      }
+    : null
   const style = {
+    ...currentColorDefault,
     height: size,
     width: size,
   }

--- a/stories/HKDropdown.stories.tsx
+++ b/stories/HKDropdown.stories.tsx
@@ -2,10 +2,8 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 
-import {
-  Align,
-  default as HKDropdown,
-} from '../src/HKDropdown'
+import { Align, default as HKDropdown } from '../src/HKDropdown'
+import { Type } from '../src/HKButton'
 
 const dropdownProps = [
   {
@@ -13,6 +11,27 @@ const dropdownProps = [
       title: 'Dropdown',
     },
     storyName: 'default',
+  },
+  {
+    props: {
+      title: 'Dropdown',
+      small: true,
+    },
+    storyName: 'small',
+  },
+  {
+    props: {
+      title: 'Dropdown',
+      type: Type.Primary,
+    },
+    storyName: 'primary',
+  },
+  {
+    props: {
+      title: 'Dropdown',
+      type: Type.Danger,
+    },
+    storyName: 'danger',
   },
   {
     props: {
@@ -50,16 +69,28 @@ const dropdownProps = [
 ]
 
 const stories = storiesOf(`HKDropdown`, module)
-dropdownProps.forEach((dropdown) => {
+dropdownProps.forEach(dropdown => {
   stories.add(dropdown.storyName, () => (
     <div>
       <HKDropdown name='story' {...dropdown.props}>
-        <li className='hk-dropdown-item' onClick={action('Dropdown-item called')}>
+        <li
+          className='hk-dropdown-item'
+          onClick={action('Dropdown-item called')}
+        >
           Callback executed onClick
         </li>
-        <li><a className='hk-dropdown-item' href='https://www.google.com'>External link </a></li>
-        <li className='hk-dropdown-divider'/>
-        <li className='hk-dropdown-item--danger' onClick={action('Dropdown-item called')}>Dangerous action </li>
+        <li>
+          <a className='hk-dropdown-item' href='https://www.google.com'>
+            External link{' '}
+          </a>
+        </li>
+        <li className='hk-dropdown-divider' />
+        <li
+          className='hk-dropdown-item--danger'
+          onClick={action('Dropdown-item called')}
+        >
+          Dangerous action{' '}
+        </li>
       </HKDropdown>
     </div>
   ))

--- a/stories/HKDropdown.stories.tsx
+++ b/stories/HKDropdown.stories.tsx
@@ -2,8 +2,8 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 
-import { Align, default as HKDropdown } from '../src/HKDropdown'
 import { Type } from '../src/HKButton'
+import { Align, default as HKDropdown } from '../src/HKDropdown'
 
 const dropdownProps = [
   {
@@ -14,8 +14,8 @@ const dropdownProps = [
   },
   {
     props: {
-      title: 'Dropdown',
       small: true,
+      title: 'Dropdown',
     },
     storyName: 'small',
   },

--- a/test/__snapshots__/Storyshots.test.js.snap
+++ b/test/__snapshots__/Storyshots.test.js.snap
@@ -2685,11 +2685,12 @@ exports[`Storyshots HKDropdown align left 1`] = `
          
         Dropdown
         <svg
-          className="fill-purple pl1"
+          className="pl1"
           style={
             Object {
-              "height": "16px",
-              "width": "16px",
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
             }
           }
         >
@@ -2732,11 +2733,60 @@ exports[`Storyshots HKDropdown align right 1`] = `
          
         Dropdown
         <svg
-          className="fill-purple pl1"
+          className="pl1"
           style={
             Object {
-              "height": "16px",
-              "width": "16px",
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
+            }
+          }
+        >
+          <use
+            xlinkHref="#caret-16"
+          />
+        </svg>
+         
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots HKDropdown danger 1`] = `
+<div>
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <div>
+    <div
+      className="relative dib"
+    >
+      <button
+        className="hk-button--danger"
+        data-testid="story-dropdown-button"
+        disabled={false}
+        onClick={[Function]}
+        title={undefined}
+        type="button"
+        value={undefined}
+      >
+         
+        Dropdown
+        <svg
+          className="pl1"
+          style={
+            Object {
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
             }
           }
         >
@@ -2779,11 +2829,12 @@ exports[`Storyshots HKDropdown default 1`] = `
          
         Dropdown
         <svg
-          className="fill-purple pl1"
+          className="pl1"
           style={
             Object {
-              "height": "16px",
-              "width": "16px",
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
             }
           }
         >
@@ -2826,11 +2877,12 @@ exports[`Storyshots HKDropdown disabled 1`] = `
          
         Dropdown
         <svg
-          className="fill-gray pl1"
+          className="pl1"
           style={
             Object {
-              "height": "16px",
-              "width": "16px",
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
             }
           }
         >
@@ -2873,11 +2925,12 @@ exports[`Storyshots HKDropdown no close dropdown onclick 1`] = `
          
         Dropdown
         <svg
-          className="fill-purple pl1"
+          className="pl1"
           style={
             Object {
-              "height": "16px",
-              "width": "16px",
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
             }
           }
         >
@@ -2919,11 +2972,108 @@ exports[`Storyshots HKDropdown no title 1`] = `
       >
          
         <svg
-          className="fill-purple"
+          className=""
           style={
             Object {
-              "height": "16px",
-              "width": "16px",
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
+            }
+          }
+        >
+          <use
+            xlinkHref="#caret-16"
+          />
+        </svg>
+         
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots HKDropdown primary 1`] = `
+<div>
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <div>
+    <div
+      className="relative dib"
+    >
+      <button
+        className="hk-button--primary"
+        data-testid="story-dropdown-button"
+        disabled={false}
+        onClick={[Function]}
+        title={undefined}
+        type="button"
+        value={undefined}
+      >
+         
+        Dropdown
+        <svg
+          className="pl1"
+          style={
+            Object {
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
+            }
+          }
+        >
+          <use
+            xlinkHref="#caret-16"
+          />
+        </svg>
+         
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots HKDropdown small 1`] = `
+<div>
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <span
+    className="isvg loading"
+    dangerouslySetInnerHTML={undefined}
+    style={undefined}
+  />
+  <div>
+    <div
+      className="relative dib"
+    >
+      <button
+        className="hk-button-sm--secondary"
+        data-testid="story-dropdown-button"
+        disabled={false}
+        onClick={[Function]}
+        title={undefined}
+        type="button"
+        value={undefined}
+      >
+         
+        Dropdown
+        <svg
+          className="pl1"
+          style={
+            Object {
+              "fill": "currentColor",
+              "height": 16,
+              "width": 16,
             }
           }
         >


### PR DESCRIPTION
Currently, `HKDropdown` isn't very customizable from a visual design perspective. By default, it:
- Always renders an `HKButton` of type `secondary`
- Always renders a large `HKButton` with no ability to make it small
- Does some logic internally to figure out what class it should apply to the caret icon, as per whether the Dropdown is disabled or not.

This PR tweaks those issues, by doing the following:
- Defaulting the internal `HKButton` style to `secondary`, but exposing a `type` prop that users can override with any of the appropriate `HKButton` types.
- Exposes a `small` prop that gets passed to the internal `HKButton`, thereby rendering a "small" dropdown.
- Uses our new-fangled `HKIcon` component instead of `MalibuIcon`, which leverages a neat CSS property called [`currentColor`](https://css-tricks.com/currentcolor/) to more programmatically determine the icon color.

### Say what, currentColor?

That's right. By default, `HKIcon` behaves just like `MalibuIcon` and expects you to pass a `fill` prop in order to display an icon of a certain color. But what if you want to inherit the icon's color from, say, the button in which it is rendered? `hk-button--primary` already decides its childrens' text colors in both the active/disabled states, so let's leverage that styling for the icon!

So, if you omit a `fill` prop for `HKIcon`, it will internally use `fill: currentColor` to get the right text color.
```
const currentColorDefault = !fill
    ? {
        fill: 'currentColor',
      }
    : null
  const style = {
    ...currentColorDefault,
    height: size,
    width: size,
  }
```
Look, ma, no logic! Just CSS 🤓 

<img width="149" alt="screen shot 2019-03-01 at 10 21 59 am" src="https://user-images.githubusercontent.com/5148596/53647585-df4a3500-3c0b-11e9-83a1-fc81185da1f0.png">
<img width="155" alt="screen shot 2019-03-01 at 10 21 55 am" src="https://user-images.githubusercontent.com/5148596/53647586-df4a3500-3c0b-11e9-8adf-df4df71a4f6f.png">
<img width="157" alt="screen shot 2019-03-01 at 10 21 50 am" src="https://user-images.githubusercontent.com/5148596/53647587-df4a3500-3c0b-11e9-98f8-50f91d3bc72c.png">
