### PR TITLE
Set up Deployment via Node + Static File Buildpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 .cache
 stats.json
 /yarn-error.log
+storybook-static

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: yarn storybook
+web: bin/boot

--- a/app.json
+++ b/app.json
@@ -14,5 +14,13 @@
         "test": "yarn run test && yarn run lint"
       }
     }
-  }
+  },
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-static"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "test": "jest --testPathPattern $PWD/test",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "release": "np"
+    "release": "np",
+    "heroku-postbuild": "build-storybook -c .storybook -o .out"
   },
   "jest": {
     "transform": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "release": "np",
-    "heroku-postbuild": "build-storybook -c .storybook -o .out"
+    "heroku-postbuild": "build-storybook -c .storybook -o storybook-static"
   },
   "jest": {
     "transform": {

--- a/static.json
+++ b/static.json
@@ -1,0 +1,3 @@
+{
+  "root": "storybook-static/"
+}


### PR DESCRIPTION
https://react-hk-components.herokuapp.com/ is currently busted.

 I suspect this is because we're trying to run Storybook in production via the `start-storybook` command, when we should be compiling the site to static files via the `build-storybook` command and serving it up with the static file buildpack.

This PR adds a `static.json` which specifies the correct `dist` directory, and also adds a `heroku-postbuild` step so that the Node buildpack compiles Storybook.

## How to Verify
Visit PR app and make sure it works!