### PR TITLE
Move storybook dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,16 @@
     "react-popper": "^1.0.2",
     "react-table": "^6.8.6",
     "react-transition-group": "^2.4.0",
-    "simple-react-modal": "0.5.1"
-  },
-  "devDependencies": {
+    "simple-react-modal": "0.5.1",
     "@storybook/addon-actions": "^4.0.7",
     "@storybook/addon-options": "^4.0.7",
     "@storybook/addon-storyshots": "^4.0.7",
     "@storybook/react": "^4.0.7",
+    "uglifyjs-webpack-plugin": "^2.0.1",
+    "copy-webpack-plugin": "^4.6.0",
+    "mini-css-extract-plugin": "^0.4.4"
+  },
+  "devDependencies": {
     "@types/classnames": "^2.2.4",
     "@types/enzyme": "^3.1.6",
     "@types/enzyme-adapter-react-15": "^1.0.1",
@@ -48,7 +51,6 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
-    "copy-webpack-plugin": "^4.6.0",
     "css-loader": "^1.0.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
@@ -65,7 +67,6 @@
     "jest": "^22.1.4",
     "jest-css-modules-transform": "^2.1.1",
     "lint-staged": "^8.1.0",
-    "mini-css-extract-plugin": "^0.4.4",
     "np": "^2.19.0",
     "prettier": "1.15.3",
     "react-hot-loader": "^4.3.1",
@@ -78,7 +79,6 @@
     "tslint-config-prettier": "^1.17.0",
     "tslint-react": "^3.4.0",
     "typescript": "2.x",
-    "uglifyjs-webpack-plugin": "^2.0.1",
     "webpack": "^4.25.1",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.1.2"


### PR DESCRIPTION
It looks like key dependencies to run storybook are in devDependencies which is most likely the source of the issue. This PR aims to get storybook's production app back up and running.

Problem
- react-hk-components production app currently fails when only deployed to production. This was evident in both stack-18 and attempting to upgrade to stack-20. Upon restarting the app and monitoring the app's logs, the following info was outputted. 

Investigating log error from production rollback

```2023-01-19T23:45:00.174220+00:00 heroku[web.1]: State changed from crashed to starting
2023-01-19T23:45:02.553647+00:00 heroku[web.1]: Starting process with command `yarn storybook`
2023-01-19T23:45:04.418523+00:00 app[web.1]: yarn run v1.22.19
2023-01-19T23:45:04.480500+00:00 app[web.1]: $ start-storybook --ci -p ${PORT:-9001} -s ./src/static -c .storybook
2023-01-19T23:45:04.490223+00:00 app[web.1]: /bin/sh: 1: start-storybook: not found
2023-01-19T23:45:04.503656+00:00 app[web.1]: error Command failed with exit code 127.
2023-01-19T23:45:04.503778+00:00 app[web.1]: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2023-01-19T23:45:04.661295+00:00 heroku[web.1]: Process exited with status 127
2023-01-19T23:45:04.726385+00:00 heroku[web.1]: State changed from starting to crashed
2023-01-19T23:51:57.661420+00:00 heroku[web.1]: State changed from crashed to starting