### PR TITLE
Update to heroku-24

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
       "value": "false"
     }
   },
-  "stack": "heroku-20",
+  "stack": "heroku-24",
   "environments": {
     "test": {
       "scripts": {


### PR DESCRIPTION
## Why the change?

Heroku-22 is reaching EOL. Thus, we have to update our apps to a newer stack version. This PR does the work of updating react-hk-components and its review apps to heroku-24. 

[GUS Ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002AQSvuYAH/view)

## Steps to verify 
+ Visit the PR app 
+ Click around and make sure that everything is alright 
+ Open up the developer tools and make sure that there are no errors 