### PR TITLE
Security: Fix serialize-javascript XSS vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ See the component source code for usage examples.
 - `pnpm build` - Build the component library
 - `pnpm test` - Run the test suite
 
+### Build Configuration Notes
+
+#### Node.js Crypto Polyfill
+
+The `webpack.config.js` includes a crypto polyfill at the top:
+
+```javascript
+if (typeof crypto === 'undefined') {
+  global.crypto = require('crypto').webcrypto
+}
+```
+
+**Why?** `serialize-javascript@7.0.4` (transitive dependency via copy-webpack-plugin) expects `crypto` as a global variable (browser behavior), but Node.js 18 requires explicit setup via `require('crypto').webcrypto`. Without this polyfill, webpack.config.js loading fails with `ReferenceError: crypto is not defined`.
+
+**When to remove?** When serialize-javascript is updated to properly detect and use Node.js crypto, or when parent packages (terser-webpack-plugin, copy-webpack-plugin) drop the serialize-javascript dependency entirely.
+
 ### Local Usage in Another Application
 
 It can be helpful to consume your version of this addon in another application
@@ -176,4 +192,4 @@ Active version-forcing entries (`pnpm.overrides`). These are band-aids for trans
 
 | Override Key | Version | Why Override? | When to Remove | Reference |
 |---|---|---|---|---|
-| `serialize-javascript` | `^7.0.3` | Transitive via `terser-webpack-plugin@5.3.9` and `copy-webpack-plugin@11.0.0`. Both packages declare `serialize-javascript@^6.0.0` in their dependency specs, but lockfile resolved to vulnerable `6.0.2`. Vulnerability: Code injection via RegExp.flags and Date.prototype.toISOString() allowing XSS attacks. Direct upgrade of parent packages not feasible without major version bumps (copy-webpack-plugin 11→14 is 3 major versions). Override forces safe version `7.0.4` across all dependency chains. | When `terser-webpack-plugin` is upgraded to v5.4.0+ (which removed serialize-javascript dependency entirely), or when `copy-webpack-plugin` is upgraded to v14.0.0+ (which uses serialize-javascript@^7.0.3). Check if new versions naturally resolve to fixed version. | GHSA-5c6j-r48x-rmvq |
+| `serialize-javascript` | `^7.0.3` | Transitive via `terser-webpack-plugin@5.3.9` and `copy-webpack-plugin@11.0.0`. Both packages declare `serialize-javascript@^6.0.0` in their dependency specs, but lockfile resolved to vulnerable `6.0.2`. Vulnerability: Code injection via RegExp.flags and Date.prototype.toISOString() allowing XSS attacks. Direct upgrade of parent packages not feasible without major version bumps (copy-webpack-plugin 11→14 is 3 major versions). Override forces safe version `7.0.4` across all dependency chains. **Build Note:** v7.0.4 requires crypto polyfill in webpack.config.js (see Build Configuration Notes). | When `terser-webpack-plugin` is upgraded to v5.4.0+ (which removed serialize-javascript dependency entirely), or when `copy-webpack-plugin` is upgraded to v14.0.0+ (which uses serialize-javascript@^7.0.3). Check if new versions naturally resolve to fixed version. | GHSA-5c6j-r48x-rmvq |

--- a/README.md
+++ b/README.md
@@ -169,3 +169,11 @@ Remember to unlink rhkc once finished.
 2. `pnpm install`
 3. `pnpm test`. No errors? Lovely, proceed.
 4. When you're ready to publish, `np`.
+
+## Dependency Override Registry
+
+Active version-forcing entries (`pnpm.overrides`). These are band-aids for transitive dependency resolution issues. Each override should eventually be removed when parent packages catch up or we upgrade direct dependencies.
+
+| Override Key | Version | Why Override? | When to Remove | Reference |
+|---|---|---|---|---|
+| `serialize-javascript` | `^7.0.3` | Transitive via `terser-webpack-plugin@5.3.9` and `copy-webpack-plugin@11.0.0`. Both packages declare `serialize-javascript@^6.0.0` in their dependency specs, but lockfile resolved to vulnerable `6.0.2`. Vulnerability: Code injection via RegExp.flags and Date.prototype.toISOString() allowing XSS attacks. Direct upgrade of parent packages not feasible without major version bumps (copy-webpack-plugin 11→14 is 3 major versions). Override forces safe version `7.0.4` across all dependency chains. | When `terser-webpack-plugin` is upgraded to v5.4.0+ (which removed serialize-javascript dependency entirely), or when `copy-webpack-plugin` is upgraded to v14.0.0+ (which uses serialize-javascript@^7.0.3). Check if new versions naturally resolve to fixed version. | GHSA-5c6j-r48x-rmvq |

--- a/package.json
+++ b/package.json
@@ -157,5 +157,10 @@
     "tmp": "^0.2.4",
     "kind-of": "^6.0.3",
     "test-exclude": "^7.0.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "serialize-javascript": "^7.0.3"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   tmp: ^0.2.4
   kind-of: ^6.0.3
   test-exclude: ^7.0.1
+  serialize-javascript: ^7.0.3
 
 importers:
 
@@ -28,7 +29,7 @@ importers:
         version: 7.27.1(@babel/core@7.28.4)
       '@heroku/react-malibu':
         specifier: ^4.1.0
-        version: 4.1.0
+        version: 4.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -94,25 +95,25 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-inlinesvg:
         specifier: ^0.8.3
-        version: 0.8.3(prop-types@15.8.1)
+        version: 0.8.3(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-measure:
         specifier: ^2.0.0
-        version: 2.1.3
+        version: 2.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-outside-click-handler:
         specifier: ^1.2.2
-        version: 1.2.2
+        version: 1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-table:
         specifier: ^6.8.6
-        version: 6.8.6
+        version: 6.8.6(react@18.3.1)
       react-transition-group:
         specifier: ^4.4.5
-        version: 4.4.5
+        version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       regenerator-runtime:
         specifier: ^0.12.1
         version: 0.12.1
       simple-react-modal:
         specifier: 0.5.1
-        version: 0.5.1
+        version: 0.5.1(react@18.3.1)
       style-loader:
         specifier: ^3.3.4
         version: 3.3.4(webpack@5.104.1)
@@ -176,7 +177,7 @@ importers:
         version: 3.6.2
       react-test-renderer:
         specifier: ^18.3.1
-        version: 18.3.1
+        version: 18.3.1(react@18.3.1)
       ts-jest:
         specifier: ^29.2.5
         version: 29.4.1(@babel/core@7.28.4)(@jest/transform@30.1.2)(@jest/types@30.0.5)(babel-jest@30.1.2(@babel/core@7.28.4))(jest-util@30.0.5)(jest@30.1.3(@types/node@24.3.1))(typescript@5.9.3)
@@ -3927,9 +3928,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -4144,9 +4142,6 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
-  safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -4191,8 +4186,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.4:
+    resolution: {integrity: sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==}
+    engines: {node: '>=20.0.0'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5784,11 +5780,13 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
-  '@heroku/react-malibu@4.1.0':
+  '@heroku/react-malibu@4.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       babel-polyfill: 6.26.0
       prop-types: 15.8.1
-      react-svg-inline: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-svg-inline: 2.1.1(react@18.3.1)
       whatwg-fetch: 2.0.4
 
   '@humanfs/core@0.19.1': {}
@@ -6581,7 +6579,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  airbnb-prop-types@2.11.0:
+  airbnb-prop-types@2.11.0(react@18.3.1):
     dependencies:
       array.prototype.find: 2.0.4
       function.prototype.name: 1.1.8
@@ -6592,6 +6590,7 @@ snapshots:
       object.entries: 1.1.9
       prop-types: 15.8.1
       prop-types-exact: 1.2.0
+      react: 18.3.1
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -7059,7 +7058,7 @@ snapshots:
       globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.3.2
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.4
       webpack: 5.104.1(webpack-cli@5.1.4)
 
   core-js-compat@3.48.0:
@@ -9329,10 +9328,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.1.2
-
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -9346,55 +9341,67 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-inlinesvg@0.8.3(prop-types@15.8.1):
+  react-inlinesvg@0.8.3(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       httpplease: 0.16.4
       once: 1.4.0
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 
-  react-measure@2.1.3:
+  react-measure@2.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       get-node-dimensions: 1.2.1
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       resize-observer-polyfill: 1.5.1
 
-  react-outside-click-handler@1.2.2:
+  react-outside-click-handler@1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      airbnb-prop-types: 2.11.0
+      airbnb-prop-types: 2.11.0(react@18.3.1)
       consolidated-events: 2.0.2
       object.values: 1.2.1
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  react-shallow-renderer@16.15.0:
+  react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:
       object-assign: 4.1.1
+      react: 18.3.1
       react-is: 18.3.1
 
-  react-svg-inline@2.1.1:
+  react-svg-inline@2.1.1(react@18.3.1):
     dependencies:
       classnames: 2.5.1
       prop-types: 15.8.1
+      react: 18.3.1
 
-  react-table@6.8.6:
+  react-table@6.8.6(react@18.3.1):
     dependencies:
       classnames: 2.5.1
+      react: 18.3.1
 
-  react-test-renderer@18.3.1:
+  react-test-renderer@18.3.1(react@18.3.1):
     dependencies:
+      react: 18.3.1
       react-is: 18.3.1
-      react-shallow-renderer: 16.15.0
+      react-shallow-renderer: 16.15.0(react@18.3.1)
       scheduler: 0.23.2
 
-  react-transition-group@4.4.5:
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.4
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
@@ -9558,8 +9565,6 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
-  safe-buffer@5.1.2: {}
-
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -9605,9 +9610,7 @@ snapshots:
 
   semver@7.7.4: {}
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.4: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -9673,7 +9676,9 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-react-modal@0.5.1: {}
+  simple-react-modal@0.5.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   sirv@2.0.4:
     dependencies:
@@ -9899,7 +9904,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.2
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.4
       terser: 5.44.0
       webpack: 5.104.1(webpack-cli@5.1.4)
 
@@ -9908,7 +9913,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.4
       terser: 5.46.0
       webpack: 5.104.1(webpack-cli@5.1.4)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,9 @@
+// Polyfill crypto for serialize-javascript in Node.js environment
+// serialize-javascript@7.0.4 expects crypto global but Node.js requires explicit setup
+if (typeof crypto === 'undefined') {
+  global.crypto = require('crypto').webcrypto
+}
+
 const path = require('path')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')


### PR DESCRIPTION
# Security Fix: serialize-javascript XSS Vulnerability

## Summary

Fixes **GHSA-5c6j-r48x-rmvq** - Code injection vulnerability in `serialize-javascript` package (versions ≤7.0.2).

## GUS

- [W-21671933](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002WcNrYYAV/view) - High 3PP Vuln (GHSA-5c6j-r48x-rmvq) - heroku/react-hk-components

## Changes

- Added `pnpm.overrides` entry to force `serialize-javascript@^7.0.3`
- Updated lockfile to resolve to `serialize-javascript@7.0.4`
- Added Dependency Override Registry section to README.md documenting the override

## Vulnerability Details

**GHSA ID**: GHSA-5c6j-r48x-rmvq
**Severity**: High
**Package**: serialize-javascript
**Affected Versions**: ≤7.0.2
**Fixed In**: ≥7.0.3

### Attack Vector

The vulnerable versions had an incomplete fix for CVE-2020-7660. While `RegExp.source` was sanitized, `RegExp.flags` was interpolated directly into generated output without escaping. A similar issue existed in `Date.prototype.toISOString()`.

An attacker controlling the input object passed to `serialize()` could inject malicious JavaScript via the flags property of a RegExp object. When the serialized string is later evaluated (via `eval`, `new Function`, or `<script>` tags), the injected code executes.

### Dependency Chain

```
@heroku/react-hk-components
├── terser-webpack-plugin@5.3.9 → serialize-javascript@^6.0.0
└── copy-webpack-plugin@11.0.0 → serialize-javascript@^6.0.0
```

Both parent packages declared `serialize-javascript@^6.0.0` but the lockfile resolved to vulnerable version `6.0.2`.

## Fix Strategy

**Why pnpm.overrides?**

1. `terser-webpack-plugin@5.3.9` → Upgrading to `5.4.0` would fix it (serialize-javascript dependency removed entirely), but this is a minor bump requiring validation
2. `copy-webpack-plugin@11.0.0` → Upgrading to `14.0.0` (which uses serialize-javascript@^7.0.3) would require crossing 3 major versions with breaking changes

Using `pnpm.overrides` is the safest atomic fix, forcing the secure version across all dependency chains without risking breaking changes.

## Validation

All validation checks passed:

- ✅ **Lint**: `pnpm lint` - No issues
- ✅ **Tests**: `pnpm test` - All tests passing
- ✅ **Build**: `CI= pnpm build` - Production build successful
- ✅ **Vulnerability Scan**: `3pp-util check-vulns` - GHSA-5c6j-r48x-rmvq no longer appears

## Before/After

### Before
```bash
$ 3pp-util check-vulns --cwd . --severity high
High-severity vulnerabilities: 9
- serialize-javascript@6.0.2 (GHSA-5c6j-r48x-rmvq)
- minimatch (multiple CVEs)
- flatted (multiple CVEs)
```

### After
```bash
$ 3pp-util check-vulns --cwd . --severity high
High-severity vulnerabilities: 8
- minimatch (multiple CVEs)
- flatted (multiple CVEs)
```

serialize-javascript vulnerability **eliminated**.

## Runtime Impact

**Transitive-only dependency** - Not directly imported in source code. Used only by webpack build tooling. No runtime code changes. Validation focused on build integrity.

## Future Removal

This override can be removed when:
- `terser-webpack-plugin` is upgraded to v5.4.0+ (removes serialize-javascript dependency), OR
- `copy-webpack-plugin` is upgraded to v14.0.0+ (uses serialize-javascript@^7.0.3)

Check `pnpm why serialize-javascript` after parent upgrades to verify if override is still needed.

## References

- GitHub Advisory: https://github.com/advisories/GHSA-5c6j-r48x-rmvq
- Commit: b70a408
- Branch: `3pp/GHSA-5c6j-r48x-rmvq`