### PR TITLE
fix(deps): bump serialize-javascript to >=7.0.5 (CVE-2026-34043)

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   },
   "pnpm": {
     "overrides": {
-      "serialize-javascript": "^7.0.3"
+      "serialize-javascript": ">=7.0.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   tmp: ^0.2.4
   kind-of: ^6.0.3
   test-exclude: ^7.0.1
-  serialize-javascript: ^7.0.3
+  serialize-javascript: '>=7.0.5'
 
 importers:
 
@@ -29,7 +29,7 @@ importers:
         version: 7.27.1(@babel/core@7.28.4)
       '@heroku/react-malibu':
         specifier: ^4.1.0
-        version: 4.1.0
+        version: 4.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -95,25 +95,25 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-inlinesvg:
         specifier: ^0.8.3
-        version: 0.8.3(prop-types@15.8.1)
+        version: 0.8.3(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-measure:
         specifier: ^2.0.0
-        version: 2.1.3
+        version: 2.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-outside-click-handler:
         specifier: ^1.2.2
-        version: 1.2.2
+        version: 1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-table:
         specifier: ^6.8.6
-        version: 6.8.6
+        version: 6.8.6(react@18.3.1)
       react-transition-group:
         specifier: ^4.4.5
-        version: 4.4.5
+        version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       regenerator-runtime:
         specifier: ^0.12.1
         version: 0.12.1
       simple-react-modal:
         specifier: 0.5.1
-        version: 0.5.1
+        version: 0.5.1(react@18.3.1)
       style-loader:
         specifier: ^3.3.4
         version: 3.3.4(webpack@5.104.1)
@@ -177,7 +177,7 @@ importers:
         version: 3.6.2
       react-test-renderer:
         specifier: ^18.3.1
-        version: 18.3.1
+        version: 18.3.1(react@18.3.1)
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.4)(@jest/transform@30.1.2)(@jest/types@30.0.5)(babel-jest@30.1.2(@babel/core@7.28.4))(jest-util@30.0.5)(jest@30.1.3(@types/node@24.3.1))(typescript@5.9.3)
@@ -4186,8 +4186,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@7.0.4:
-    resolution: {integrity: sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
 
   set-function-length@1.2.2:
@@ -5780,11 +5780,13 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
-  '@heroku/react-malibu@4.1.0':
+  '@heroku/react-malibu@4.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       babel-polyfill: 6.26.0
       prop-types: 15.8.1
-      react-svg-inline: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-svg-inline: 2.1.1(react@18.3.1)
       whatwg-fetch: 2.0.4
 
   '@humanfs/core@0.19.1': {}
@@ -6577,7 +6579,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  airbnb-prop-types@2.11.0:
+  airbnb-prop-types@2.11.0(react@18.3.1):
     dependencies:
       array.prototype.find: 2.0.4
       function.prototype.name: 1.1.8
@@ -6588,6 +6590,7 @@ snapshots:
       object.entries: 1.1.9
       prop-types: 15.8.1
       prop-types-exact: 1.2.0
+      react: 18.3.1
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -7055,7 +7058,7 @@ snapshots:
       globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.3.2
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       webpack: 5.104.1(webpack-cli@5.1.4)
 
   core-js-compat@3.48.0:
@@ -9338,55 +9341,67 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-inlinesvg@0.8.3(prop-types@15.8.1):
+  react-inlinesvg@0.8.3(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       httpplease: 0.16.4
       once: 1.4.0
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 
-  react-measure@2.1.3:
+  react-measure@2.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       get-node-dimensions: 1.2.1
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       resize-observer-polyfill: 1.5.1
 
-  react-outside-click-handler@1.2.2:
+  react-outside-click-handler@1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      airbnb-prop-types: 2.11.0
+      airbnb-prop-types: 2.11.0(react@18.3.1)
       consolidated-events: 2.0.2
       object.values: 1.2.1
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
-  react-shallow-renderer@16.15.0:
+  react-shallow-renderer@16.15.0(react@18.3.1):
     dependencies:
       object-assign: 4.1.1
+      react: 18.3.1
       react-is: 18.3.1
 
-  react-svg-inline@2.1.1:
+  react-svg-inline@2.1.1(react@18.3.1):
     dependencies:
       classnames: 2.5.1
       prop-types: 15.8.1
+      react: 18.3.1
 
-  react-table@6.8.6:
+  react-table@6.8.6(react@18.3.1):
     dependencies:
       classnames: 2.5.1
+      react: 18.3.1
 
-  react-test-renderer@18.3.1:
+  react-test-renderer@18.3.1(react@18.3.1):
     dependencies:
+      react: 18.3.1
       react-is: 18.3.1
-      react-shallow-renderer: 16.15.0
+      react-shallow-renderer: 16.15.0(react@18.3.1)
       scheduler: 0.23.2
 
-  react-transition-group@4.4.5:
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.4
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
@@ -9595,7 +9610,7 @@ snapshots:
 
   semver@7.7.4: {}
 
-  serialize-javascript@7.0.4: {}
+  serialize-javascript@7.0.5: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -9661,7 +9676,9 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-react-modal@0.5.1: {}
+  simple-react-modal@0.5.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   sirv@2.0.4:
     dependencies:
@@ -9887,7 +9904,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.2
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       terser: 5.44.0
       webpack: 5.104.1(webpack-cli@5.1.4)
 
@@ -9896,7 +9913,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       terser: 5.46.0
       webpack: 5.104.1(webpack-cli@5.1.4)
 


### PR DESCRIPTION
## Summary
- Updates pnpm override for `serialize-javascript` from `^7.0.3` to `>=7.0.5`
- Resolves CVE-2026-34043 (P2/medium): CPU Exhaustion DoS via crafted array-like objects
- Previous PR #190 fixed GHSA-5c6j-r48x-rmvq (XSS) but this newer CVE requires 7.0.5

GUS: https://gus.lightning.force.com/lightning/r/a07EE00002Y71FvYAJ/view

## Test plan
- [ ] CI passes
- [ ] Verify serialize-javascript resolves to >=7.0.5 in lockfile