### PR TITLE
verification: add Smoke barrel + UMD smoke test

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "build": "npm run clean && tsc --project tsconfig.build.json && webpack",
     "clean": "rm -rf ./dist",
     "prepublishOnly": "npm run build",
-    "test": "jest --testPathPatterns $PWD/test/helpers.test.tsx",
+    "test": "jest --testPathPatterns \"$PWD/test/helpers.test.tsx|$PWD/test/smoke.test.tsx\"",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "release": "np"

--- a/test/smoke.test.tsx
+++ b/test/smoke.test.tsx
@@ -1,0 +1,86 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Smoke test -- layer-L4 of the heroku/3pp-grackle verification ladder.
+ *
+ * react and react-dom are peerDependencies (not installed during
+ * `npm install`), so a runtime import of `../src` would fail with
+ * "Cannot find module 'react'". Instead, this test exercises the
+ * regression class most likely from a 3pp dependency bump
+ * (React/Babel/d3/typescript major bumps -> barrel breakage,
+ * missing-import fallout, file rename without barrel update):
+ *
+ *   1. `src/index.ts` exports every name advertised in the README/
+ *      docs as a named export -- catches accidental rename or removal.
+ *   2. Each component file exists at the path implied by the barrel --
+ *      catches a deleted file the barrel still re-exports.
+ *   3. `dist/umd/react-hk-components.js` (after build) exists and is
+ *      non-trivial -- catches catastrophic webpack/babel breakage.
+ *
+ * (3) only runs when `dist/` has been built; in CI the order is
+ * `npm run build && npm test` so the asset is present. Locally,
+ * the test gracefully no-ops if dist is absent.
+ */
+
+const repoRoot = path.resolve(__dirname, '..')
+const indexTs = fs.readFileSync(
+  path.join(repoRoot, 'src', 'index.ts'),
+  'utf8',
+)
+
+const expectedExports = [
+  'HKBanner',
+  'HKBarChart',
+  'HKButton',
+  'HKTextField',
+  'HKDropdown',
+  'HKFlagIcon',
+  'HKLineChart',
+  'HKModal',
+  'HKTable',
+  'HKIcon',
+  'HKIconSprites',
+  'Sprites',
+  'HKTablePagination',
+  'HKTableHeader',
+  'Fills',
+  'ProductIcons',
+  'MarketingIcons',
+]
+
+describe('Smoke | barrel surface', () => {
+  it.each(expectedExports)('exports %s from src/index.ts', (name) => {
+    const re = new RegExp(`\\b${name}\\b`)
+    expect(re.test(indexTs)).toBe(true)
+  })
+
+  it('every default-export source file referenced by the barrel exists', () => {
+    const reExportLines = indexTs
+      .split('\n')
+      .filter((line) => line.includes("from './HK"))
+    expect(reExportLines.length).toBeGreaterThan(0)
+    for (const line of reExportLines) {
+      const match = line.match(/from\s+'\.\/([A-Z][A-Za-z]+)'/)
+      if (!match) continue
+      const file = match[1]
+      const exists = fs.existsSync(path.join(repoRoot, 'src', `${file}.tsx`))
+      expect(exists).toBe(true)
+    }
+  })
+})
+
+describe('Smoke | UMD bundle (when built)', () => {
+  const distPath = path.join(repoRoot, 'dist', 'umd', 'react-hk-components.js')
+
+  it('dist/umd/react-hk-components.js exists and is non-trivial after build', () => {
+    if (!fs.existsSync(distPath)) {
+      console.warn(
+        '  [skip] dist/ not built. Run `npm run build` to exercise this assertion.',
+      )
+      return
+    }
+    const stat = fs.statSync(distPath)
+    expect(stat.size).toBeGreaterThan(50_000) // arbitrarily small floor; current build ~1.5MB
+  })
+})


### PR DESCRIPTION
## Summary

Layer-L4 smoke test for `@heroku/react-hk-components`, catching the
regression class most likely from a 3pp dependency bump
(React/Babel/d3/typescript major bumps → barrel breakage,
missing-import fallout, file rename without barrel update).

```bash
npm test    # 23/23 pass: 4 existing helpers + 19 new smoke
```

## What it asserts

| # | Test class | Assertion |
|---|---|---|
| 1 | `Smoke \| barrel surface` | `src/index.ts` re-exports each of the 17 named exports advertised in the README |
| 2 | `Smoke \| barrel surface` | Every component file referenced by the barrel exists at `src/<Name>.tsx` |
| 3 | `Smoke \| UMD bundle (when built)` | `dist/umd/react-hk-components.js` exists and is non-trivial (>50KB) — only enforced when `dist/` is present, gracefully skips otherwise |

## Why no DOM-render smoke?

`react` and `react-dom` are **peerDependencies** here, not devDeps —
they aren't installed by `npm install`. A runtime import of `../src`
fails with `Cannot find module 'react'`. A barrel/UMD smoke covers the
same regression class (broken exports, broken file paths, broken
build) without ballooning the install surface for what is published
as an externals-aware UMD bundle.

If reviewers want true DOM-render coverage in a follow-up, the right
move is to install `react@^18`, `react-dom@^18`, `@testing-library/react`,
and `jest-environment-jsdom` as devDeps — those are non-trivial install
adds, so I left them out of this PR. The barrel smoke is the right
shape for catching publish-surface regressions today.

## Companion CI workflow (manual apply)

The agent that authored this PR is prevented by a corporate security
hook from writing `.github/workflows/*.yml` directly. To turn this
smoke into a real PR gate, add the following workflow as a follow-up
commit on this branch:

```yaml
name: ci

on:
  push:
    branches: [main]
  pull_request:

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: 18.20.0
          cache: npm
      - run: npm ci --no-audit --no-fund
      - run: npm run lint
      - run: npm run build
      - run: npm test
```

Note the deliberate ordering: `build` before `test` so the L4 UMD
smoke assertion (#3) actually runs in CI. Expected runtime: ~2 min.

## Test plan

- [x] `npm install` clean
- [x] `npm test` → 23/23 pass (4 helpers + 19 smoke)
- [x] After `npm run build`, dist UMD assertion runs and passes
- [ ] Reviewer adds CI workflow file in a follow-up commit (see above)

## Notes / caveats

- Tracked in `heroku/3pp-grackle` —
  [`docs/verification-specs/react-hk-components.md`](https://github.com/heroku/3pp-grackle/blob/main/docs/verification-specs/react-hk-components.md).
- Branch `verification/smoke-suite` matches the convention used by
  pilot PRs in `heroku/react-malibu#100`, `heroku/12factor#391`,
  `heroku/ember-backboard#113`, `heroku/ember-hk-components#302`,
  `heroku/ember-malibu-icon#211`.
- One small change to `package.json#scripts.test`: the pattern was
  hardcoded to `helpers.test.tsx`; expanded to also pick up
  `smoke.test.tsx`. The original behavior is preserved.
